### PR TITLE
Use RFC3339 as time encoder layout on logs

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -14,7 +14,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	snitchundistroiov1alpha1 "github.com/getupio-undistro/snitch/api/v1alpha1"
+	"github.com/getupio-undistro/snitch/api/v1alpha1"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -46,7 +46,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
-	err = snitchundistroiov1alpha1.AddToScheme(scheme.Scheme)
+	err = v1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	//+kubebuilder:scaffold:scheme

--- a/main.go
+++ b/main.go
@@ -3,11 +3,13 @@ package main
 import (
 	"flag"
 	"os"
+	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -15,7 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	snitchundistroiov1alpha1 "github.com/getupio-undistro/snitch/api/v1alpha1"
+	"github.com/getupio-undistro/snitch/api/v1alpha1"
 	"github.com/getupio-undistro/snitch/controllers"
 	//+kubebuilder:scaffold:imports
 )
@@ -28,7 +30,7 @@ var (
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
-	utilruntime.Must(snitchundistroiov1alpha1.AddToScheme(scheme))
+	utilruntime.Must(v1alpha1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 
@@ -43,6 +45,7 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	opts := zap.Options{
 		Development: true,
+		TimeEncoder: zapcore.TimeEncoderOfLayout(time.RFC3339),
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()


### PR DESCRIPTION
## Description
1. Use RFC3339 as time encoder layout on logs
2. Renaming alias of our API package import

Before:
```
1.6498535028185341e+09  INFO    controller.cluster      reconciliation finished, next run in 10m        {"reconciler group": "snitch.undistro.io", "reconciler kind": "Cluster", "name": "harbor", "namespace": "snitch", "name": "harbor", "namespace": "snitch"}
```
After:
```
2022-04-13T09:37:29-03:00       INFO    controller.cluster      reconciliation finished, next run in 10m        {"reconciler group": "snitch.undistro.io", "reconciler kind": "Cluster", "name": "harbor", "namespace": "snitch", "name": "harbor", "namespace": "snitch"}
```

## Linked Issues
There is no linked issues.

## How has this been tested?
Run the operator (`make run`) and see the logs.

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/getupio-undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [x] My changes are covered by tests
