### PR TITLE
Split snitch-view script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,5 +173,7 @@ setup-minikube:  ## Start Minikube with an inner Docker registry.
 delete-minikube: ## Delete Minikube node.
 	minikube delete
 
-setup-snitch-view: ## Configure RBAC, create and apply view Secret.
+gen-snitch-view-kubeconfig: ## Create a service account and config RBAC for it.
+	./scripts/gen_snitch_view_kubeconfig.sh
+setup-snitch-view: ## Create and apply Snitch View Secret.
 	./scripts/setup_snitch_view.sh

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,6 +5,12 @@ generatorOptions:
   disableNameSuffixHash: true
 
 configMapGenerator:
-- name: manager-config
-  files:
+- files:
   - controller_manager_config.yaml
+  name: manager-config
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: localhost:5000/snitch
+  newTag: latest

--- a/scripts/gen_snitch_view_kubeconfig.sh
+++ b/scripts/gen_snitch_view_kubeconfig.sh
@@ -1,0 +1,166 @@
+#!/bin/sh
+set -o errexit
+
+KCONFIG_NAME=${KCONFIG_NAME:-"snitch-view-kubeconfig.yaml"}
+CLUSTER_ROLE_NAME=${CLUSTER_ROLE_NAME:-"snitch-view"}
+SVC_ACCOUNT_NS=${SVC_ACCOUNT_NS:-"kube-system"}
+SVC_ACCOUNT_NAME=${SVC_ACCOUNT_NAME:-"snitch-view"}
+
+get_token_name() {
+	echo $(kubectl -n $SVC_ACCOUNT_NS \
+		get serviceaccount $SVC_ACCOUNT_NAME \
+		-o=jsonpath='{.secrets[0].name}'
+	)
+}
+get_token_value() {
+	echo $(kubectl -n $SVC_ACCOUNT_NS \
+		get secret $TOKEN_NAME \
+		-o=jsonpath='{.data.token}' | base64 --decode
+	)
+}
+get_current_context() {
+	echo $(kubectl config current-context)
+}
+get_current_cluster() {
+	echo $(kubectl config view \
+		--raw -o=go-template='
+			{{range .contexts}}
+				{{if eq .name "'$CURRENT_CONTEXT'"}}
+					{{index .context "cluster"}}
+				{{end}}
+			{{end}}
+		'
+	)
+}
+get_cluster_ca() {
+	echo $(kubectl config view \
+		--raw -o=go-template='
+			{{range .clusters}}
+				{{if eq .name "'$CURRENT_CLUSTER'"}}
+					{{with index .cluster "certificate-authority-data"}}
+						{{.}}
+					{{end}}
+				{{end}}
+			{{end}}
+		'
+	)
+}
+get_cluster_server() {
+	echo $(kubectl config view \
+		--raw -o=go-template='
+			{{range .clusters}}
+				{{if eq .name "'$CURRENT_CLUSTER'"}}
+					{{ .cluster.server }}
+				{{end}}
+			{{end}}
+		'
+	)
+}
+
+create_svc_account() {
+	kubectl -n $SVC_ACCOUNT_NS create serviceaccount $SVC_ACCOUNT_NAME
+}
+
+create_cluster_role() {
+cat << EOF | kubectl apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: $CLUSTER_ROLE_NAME
+rules:
+  - apiGroups: [ "" ]
+    resources:
+      - configmaps
+      - deployments
+      - endpoints
+      - horizontalpodautoscalers
+      - namespaces
+      - nodes
+      - persistentvolumes
+      - persistentvolumeclaims
+      - pods
+      - secrets
+      - serviceaccounts
+      - services
+      - statefulsets
+    verbs: [ "get", "list" ]
+  - apiGroups: [ "rbac.authorization.k8s.io" ]
+    resources:
+      - clusterroles
+      - clusterrolebindings
+      - roles
+      - rolebindings
+    verbs: [ "get", "list" ]
+  - apiGroups: [ "metrics.k8s.io" ]
+    resources:
+      - pods
+      - nodes
+    verbs: [ "get", "list" ]
+EOF
+}
+
+create_cluster_role_binding() {
+	kubectl create clusterrolebinding $SVC_ACCOUNT_NAME \
+		--clusterrole=snitch-view \
+		--serviceaccount=$SVC_ACCOUNT_NS:$SVC_ACCOUNT_NAME
+}
+
+create_kubeconfig() {
+cat << EOF > $KCONFIG_NAME
+apiVersion: v1
+kind: Config
+current-context: $CURRENT_CONTEXT
+contexts:
+  - name: $CURRENT_CONTEXT
+    context:
+      cluster: $CURRENT_CONTEXT
+      user: snitch-view
+      namespace: kube-system
+clusters:
+  - name: $CURRENT_CONTEXT
+    cluster:
+      certificate-authority-data: $CLUSTER_CA
+      server: $CLUSTER_SERVER
+users:
+  - name: snitch-view
+    user:
+      token: $TOKEN_VALUE
+EOF
+}
+
+
+setup_namespaces() {
+	if ! kubectl get namespace $SVC_ACCOUNT_NS > /dev/null 2>&1; then
+		kubectl create namespace $SVC_ACCOUNT_NS
+	fi
+}
+setup_svc_account() {
+	if ! kubectl -n $SVC_ACCOUNT_NS get serviceaccount $SVC_ACCOUNT_NAME > /dev/null 2>&1; then
+		create_svc_account
+	fi
+}
+setup_cluster_role() {
+	if ! kubectl get clusterrole $CLUSTER_ROLE_NAME > /dev/null 2>&1; then
+		create_cluster_role
+	fi
+}
+setup_cluster_role_binding() {
+	if ! kubectl get -n $SVC_ACCOUNT_NS clusterrolebinding $SVC_ACCOUNT_NAME > /dev/null 2>&1; then
+		create_cluster_role_binding
+	fi
+}
+
+
+setup_namespaces
+setup_svc_account
+
+TOKEN_NAME=${TOKEN_NAME:-"$(get_token_name)"}
+TOKEN_VALUE=${TOKEN_VALUE:-"$(get_token_value)"}
+CURRENT_CONTEXT=${CURRENT_CONTEXT:-"$(get_current_context)"}
+CURRENT_CLUSTER=${CURRENT_CLUSTER:-"$(get_current_cluster)"}
+CLUSTER_CA=${CLUSTER_CA:-"$(get_cluster_ca)"}
+CLUSTER_SERVER=${CLUSTER_SERVER:-"$(get_cluster_server)"}
+
+setup_cluster_role_binding
+setup_cluster_role_binding
+create_kubeconfig

--- a/scripts/setup_snitch_view.sh
+++ b/scripts/setup_snitch_view.sh
@@ -5,135 +5,17 @@ CLUSTER_NAME=${CLUSTER_NAME:-"snitched"}
 CLUSTER_NS=${CLUSTER_NS:-"snitch-system"}
 KCONFIG_NAME=${KCONFIG_NAME:-"snitch-view-kubeconfig.yaml"}
 KCONFIG_SECRET_NAME=${KCONFIG_SECRET_NAME:-"$CLUSTER_NAME-kubeconfig"}
-CLUSTER_ROLE_NAME=${CLUSTER_ROLE_NAME:-"snitch-view"}
-SVC_ACCOUNT_NS=${SVC_ACCOUNT_NS:-"kube-system"}
-SVC_ACCOUNT_NAME=${SVC_ACCOUNT_NAME:-"snitch-view"}
 
-get_token_name() {
-	echo $(kubectl -n $SVC_ACCOUNT_NS \
-		get serviceaccount $SVC_ACCOUNT_NAME \
-		-o=jsonpath='{.secrets[0].name}'
-	)
+setup_namespaces() {
+	if ! kubectl get namespace $CLUSTER_NS > /dev/null 2>&1; then
+		kubectl create namespace $CLUSTER_NS 
+	fi
 }
-get_token_value() {
-	echo $(kubectl -n $SVC_ACCOUNT_NS \
-		get secret $TOKEN_NAME \
-		-o=jsonpath='{.data.token}' | base64 --decode
-	)
-}
-get_current_context() {
-	echo $(kubectl config current-context)
-}
-get_current_cluster() {
-	echo $(kubectl config view \
-		--raw -o=go-template='
-			{{range .contexts}}
-				{{if eq .name "'$CURRENT_CONTEXT'"}}
-					{{index .context "cluster"}}
-				{{end}}
-			{{end}}
-		'
-	)
-}
-get_cluster_ca() {
-	echo $(kubectl config view \
-		--raw -o=go-template='
-			{{range .clusters}}
-				{{if eq .name "'$CURRENT_CLUSTER'"}}
-					{{with index .cluster "certificate-authority-data"}}
-						{{.}}
-					{{end}}
-				{{end}}
-			{{end}}
-		'
-	)
-}
-get_cluster_server() {
-	echo $(kubectl config view \
-		--raw -o=go-template='
-			{{range .clusters}}
-				{{if eq .name "'$CURRENT_CLUSTER'"}}
-					{{ .cluster.server }}
-				{{end}}
-			{{end}}
-		'
-	)
-}
-
-create_svc_account() {
-	kubectl -n $SVC_ACCOUNT_NS create serviceaccount $SVC_ACCOUNT_NAME
-}
-
-create_cluster_role() {
-cat << EOF | kubectl apply -f -
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: $CLUSTER_ROLE_NAME
-rules:
-  - apiGroups: [ "" ]
-    resources:
-      - configmaps
-      - deployments
-      - endpoints
-      - horizontalpodautoscalers
-      - namespaces
-      - nodes
-      - persistentvolumes
-      - persistentvolumeclaims
-      - pods
-      - secrets
-      - serviceaccounts
-      - services
-      - statefulsets
-    verbs: [ "get", "list" ]
-  - apiGroups: [ "rbac.authorization.k8s.io" ]
-    resources:
-      - clusterroles
-      - clusterrolebindings
-      - roles
-      - rolebindings
-    verbs: [ "get", "list" ]
-  - apiGroups: [ "metrics.k8s.io" ]
-    resources:
-      - pods
-      - nodes
-    verbs: [ "get", "list" ]
-EOF
-}
-
-create_cluster_role_binding() {
-	kubectl create clusterrolebinding $SVC_ACCOUNT_NAME \
-		--clusterrole=snitch-view \
-		--serviceaccount=$SVC_ACCOUNT_NS:$SVC_ACCOUNT_NAME
-}
-
-create_kubeconfig() {
-cat << EOF > $KCONFIG_NAME
-apiVersion: v1
-kind: Config
-current-context: $CURRENT_CONTEXT
-contexts:
-  - name: $CURRENT_CONTEXT
-    context:
-      cluster: $CURRENT_CONTEXT
-      user: snitch-view
-      namespace: kube-system
-clusters:
-  - name: $CURRENT_CONTEXT
-    cluster:
-      certificate-authority-data: $CLUSTER_CA
-      server: $CLUSTER_SERVER
-users:
-  - name: snitch-view
-    user:
-      token: $TOKEN_VALUE
-EOF
-}
-
-create_kubeconfig_secret() {
-	kubectl create secret generic $KCONFIG_SECRET_NAME \
-	  --from-file=value=$KCONFIG_NAME
+setup_kubeconfig_secret() {
+	if ! kubectl get secret $KCONFIG_SECRET_NAME > /dev/null 2>&1; then
+		kubectl create secret generic $KCONFIG_SECRET_NAME \
+			--from-file=value=$KCONFIG_NAME
+	fi
 }
 
 apply_cluster_crd() {
@@ -149,47 +31,7 @@ spec:
 EOF
 }
 
-setup_svc_account() {
-	if ! kubectl -n $SVC_ACCOUNT_NS get serviceaccount $SVC_ACCOUNT_NAME > /dev/null 2>&1; then
-		create_svc_account
-	fi
-}
-setup_cluster_role() {
-	if ! kubectl get clusterrole $CLUSTER_ROLE_NAME > /dev/null 2>&1; then
-		create_cluster_role
-	fi
-}
-setup_cluster_role_binding() {
-	if ! kubectl get -n $SVC_ACCOUNT_NS clusterrolebinding $SVC_ACCOUNT_NAME > /dev/null 2>&1; then
-		create_cluster_role_binding
-	fi
-}
-setup_kubeconfig_secret() {
-	if ! kubectl get secret $KCONFIG_SECRET_NAME > /dev/null 2>&1; then
-		create_kubeconfig_secret
-	fi
-}
-setup_namespaces() {
-	if ! kubectl get namespace $SVC_ACCOUNT_NS > /dev/null 2>&1; then
-		kubectl create namespace $SVC_ACCOUNT_NS
-	fi
-	if ! kubectl get namespace $CLUSTER_NS > /dev/null 2>&1; then
-		kubectl create namespace $CLUSTER_NS 
-	fi
-}
 
 setup_namespaces
-setup_svc_account
-
-TOKEN_NAME=${TOKEN_NAME:-"$(get_token_name)"}
-TOKEN_VALUE=${TOKEN_VALUE:-"$(get_token_value)"}
-CURRENT_CONTEXT=${CURRENT_CONTEXT:-"$(get_current_context)"}
-CURRENT_CLUSTER=${CURRENT_CLUSTER:-"$(get_current_cluster)"}
-CLUSTER_CA=${CLUSTER_CA:-"$(get_cluster_ca)"}
-CLUSTER_SERVER=${CLUSTER_SERVER:-"$(get_cluster_server)"}
-
-setup_cluster_role_binding
-setup_cluster_role_binding
-create_kubeconfig
 setup_kubeconfig_secret
 apply_cluster_crd


### PR DESCRIPTION
## Description
This separation is due to a distinction in Kubernetes contexts, one for
the watched cluster and another for Snitch.

In the \<setup_snitch_view.sh\> script remains the functions which create
the Secret with the generated kubeconfig and a Cluster instance. A new
script called \<gen_snitch_view_kubeconfig.sh\> has been added, being
responsible for creating a service account and configure RBAC for it in 
the watched cluster.

## How has this been tested?
Local executions were performed to assert the script's stability.

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/getupio-undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [x] My changes are covered by tests
