### PR TITLE
add environment field in cluster payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,11 +156,18 @@ kind: Cluster
 metadata:
   name: mycluster
   namespace: snitch-system
+  labels:
+    snitch.undistro.io/environment: prod
 spec:
   kubeconfigRef:
     name: mycluster-kubeconfig
 EOF
 ```
+
+> **Tip:**
+> Clusters can be grouped by environment with the `snitch.undistro.io/environment` label.
+> 
+> You can list all clusters from `prod` environment using: `kubectl get clusters -l snitch.undistro.io/environment=prod`
 
 ## Uninstall
 

--- a/apis/snitch/v1alpha1/cluster_types.go
+++ b/apis/snitch/v1alpha1/cluster_types.go
@@ -11,6 +11,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+const LabelEnvironment = "snitch.undistro.io/environment"
+
 // ClusterSpec defines the desired state of Cluster
 type ClusterSpec struct {
 	// KubeconfigRef is a reference to a secret that contains the kubeconfig data

--- a/config/samples/_v1alpha1_cluster.yaml
+++ b/config/samples/_v1alpha1_cluster.yaml
@@ -2,6 +2,8 @@ apiVersion: snitch.undistro.io/v1alpha1
 kind: Cluster
 metadata:
   name: cluster-sample
+  labels:
+    snitch.undistro.io/environment: prod
 spec:
   kubeconfigRef:
     name: sample-kubeconfig

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -38,6 +38,9 @@ components:
         namespace:
           type: string
           example: clusters-prod
+        environment:
+          type: string
+          example: prod
         provider:
           type: string
           example: aws

--- a/payloads/clusters.go
+++ b/payloads/clusters.go
@@ -26,6 +26,7 @@ func NewCluster(c v1alpha1.Cluster) Cluster {
 	return Cluster{
 		Name:              c.Name,
 		Namespace:         c.Namespace,
+		Environment:       c.Labels[v1alpha1.LabelEnvironment],
 		Provider:          "aws",
 		Flavor:            "eks",
 		Region:            "us-east-1",
@@ -41,6 +42,7 @@ func NewCluster(c v1alpha1.Cluster) Cluster {
 type Cluster struct {
 	Name              string      `json:"name,omitempty"`
 	Namespace         string      `json:"namespace,omitempty"`
+	Environment       string      `json:"environment,omitempty"`
 	Provider          string      `json:"provider,omitempty"`
 	Flavor            string      `json:"flavor,omitempty"`
 	Region            string      `json:"region,omitempty"`


### PR DESCRIPTION
## Description
Add environment field in cluster payload

## Linked Issues
https://getupio.atlassian.net/browse/UD-8

## How has this been tested?
1. label a cluster: `k label cluster mycluster snitch.undistro.io/environment=prod`
2. make a GET request to server: `curl localhost:3000/api/v1/clusters -s | jq .`
```json
[
  {
    "name": "mycluster",
    "namespace": "snitch-system",
    "environment": "prod",
    "provider": "aws",
    "flavor": "eks",
    "region": "us-east-1",
    "totalNodes": 3,
    "ready": true,
    "version": "v1.21.5-eks-bc4871b",
    "resources": {
      "memory": {
        "available": "10033Mi",
        "usage": "3230Mi",
        "usagePercentage": 32
      },
      "cpu": {
        "available": "5790m",
        "usage": "681m",
        "usagePercentage": 11
      }
    },
    "creationTimestamp": "2022-03-17T19:45:07Z"
  }
]
```

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/getupio-undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [ ] My changes are covered by tests
