### PR TITLE
remove flavor field from API

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -44,9 +44,6 @@ components:
         provider:
           type: string
           example: aws
-        flavor:
-          type: string
-          example: eks
         region:
           type: string
           example: v1.21.5-eks-bc4871b

--- a/payloads/clusters.go
+++ b/payloads/clusters.go
@@ -28,7 +28,6 @@ func NewCluster(c v1alpha1.Cluster) Cluster {
 		Namespace:         c.Namespace,
 		Environment:       c.Labels[v1alpha1.LabelEnvironment],
 		Provider:          "aws",
-		Flavor:            "eks",
 		Region:            "us-east-1",
 		TotalNodes:        c.Status.TotalNodes,
 		Ready:             true,
@@ -44,7 +43,6 @@ type Cluster struct {
 	Namespace         string      `json:"namespace,omitempty"`
 	Environment       string      `json:"environment,omitempty"`
 	Provider          string      `json:"provider,omitempty"`
-	Flavor            string      `json:"flavor,omitempty"`
 	Region            string      `json:"region,omitempty"`
 	TotalNodes        int         `json:"totalNodes,omitempty"`
 	Ready             bool        `json:"ready,omitempty"`


### PR DESCRIPTION
## Description
Removing `flavor` field from API.

## Linked Issues
https://getupio.atlassian.net/browse/UD-59

## How has this been tested?
Run server and make a GET request `curl localhost:3000/api/v1/clusters -s | jq .`:
```json
[
  {
    "name": "mycluster",
    "namespace": "snitch-system",
    "environment": "prod",
    "provider": "aws",
    "region": "us-east-1",
    "totalNodes": 3,
    "ready": true,
    "version": "v1.21.5-eks-bc4871b",
    "resources": {
      "memory": {
        "available": "10033Mi",
        "usage": "3229Mi",
        "usagePercentage": 32
      },
      "cpu": {
        "available": "5790m",
        "usage": "649m",
        "usagePercentage": 11
      }
    },
    "creationTimestamp": "2022-03-17T19:45:07Z"
  }
]
```

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/getupio-undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [ ] My changes are covered by tests
