### PR TITLE
add DOKS label

### DIFF
--- a/pkg/discovery/cluster_labels.go
+++ b/pkg/discovery/cluster_labels.go
@@ -3,7 +3,8 @@ package discovery
 const RegionLabel = "topology.kubernetes.io/region"
 
 var ClusterSourcePrefixes = map[string]string{
-	"cloud.google.com/gke":  "gcp",
-	"eks.amazonaws.com/":    "aws",
-	"kubernetes.azure.com/": "azure",
+	"cloud.google.com/gke":   "gcp",
+	"eks.amazonaws.com/":     "aws",
+	"kubernetes.azure.com/":  "azure",
+	"doks.digitalocean.com/": "digitalocean",
 }


### PR DESCRIPTION
## Description
Add label to discover DigitalOcean cluster providers.

## Linked Issues
https://getupio.atlassian.net/browse/UD-60

## How has this been tested?
Connecting a DOKS cluster
```shell
kubectl get clusters -o=wide
NAME          VERSION               MEM AVAILABLE   MEM USAGE (%)   CPU AVAILABLE   CPU USAGE (%)   NODES   AGE   PROVIDER       REGION
dokscluster   v1.22.8               1574Mi          804Mi (51%)     1900m           74m (3%)        1       20m   digitalocean   nyc1
mycluster     v1.21.5-eks-bc4871b   10033Mi         2752Mi (27%)    5790m           581m (10%)      3       42d   aws            us-east-1
```

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/getupio-undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [ ] My changes are covered by tests
