### PR TITLE
Add OKE label

### DIFF
--- a/pkg/discovery/cluster_labels.go
+++ b/pkg/discovery/cluster_labels.go
@@ -7,4 +7,5 @@ var ClusterSourcePrefixes = map[string]string{
 	"eks.amazonaws.com/":     "aws",
 	"kubernetes.azure.com/":  "azure",
 	"doks.digitalocean.com/": "digitalocean",
+	"oke.oraclecloud.com/":   "oraclecloud",
 }


### PR DESCRIPTION
## Description
Add labels to discover OKE clusters from oracle cloud

## Linked Issues
https://getupio.atlassian.net/browse/UD-61

## How has this been tested?
Connecting a OKE cluster
```
kubectl get clusters -o=wide
NAME         VERSION               MEM AVAILABLE   MEM USAGE (%)   CPU AVAILABLE   CPU USAGE (%)   NODES   AGE   PROVIDER      REGION
mycluster    v1.21.5-eks-bc4871b   10033Mi         2750Mi (27%)    5790m           591m (10%)      3       42d   aws           us-east-1
okecluster   v1.22.5               3535Mi          1260Mi (35%)    2000m           31m (1%)        1       32m   oraclecloud   sa-vinhedo-1
```

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/getupio-undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [ ] My changes are covered by tests
