### PR TITLE
Improve self-hosted cluster detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,10 +161,13 @@ endef
 
 
 ##@ Local Deployment
+setup-region-label: # Add label used by Undistro Inspect to detect the cluster region.
+	./scripts/setup_region_label.sh
 setup-local-registry: ## Create a local Docker registry.
 	./scripts/setup_local_registry.sh
 setup-kind: setup-local-registry ## Start Kind and a local Docker registry.
 	./scripts/setup_kind.sh
+	$(MAKE) setup-region-label
 delete-kind: ## Delete Kind node.
 	kind delete cluster
 setup-minikube:  ## Start Minikube with an inner Docker registry.
@@ -174,6 +177,7 @@ setup-minikube:  ## Start Minikube with an inner Docker registry.
 		--container-runtime=containerd \
 		--insecure-registry="${MINIK_ADDR}:${REG_PORT}" \
 		--extra-config="kubelet.container-runtime-endpoint='http://${MINIK_ADDR}:${REG_PORT}"
+	$(MAKE) setup-region-label
 delete-minikube: ## Delete Minikube node.
 	minikube delete
 
@@ -184,7 +188,7 @@ setup-inspect-view: ## Create and apply view secret.
 
 ##@ Documentation
 helm-docs: ## Generate documentation for helm charts
-	@docker run -it --rm \
+	@ docker run -it --rm \
 		-v $(PWD):/helm-docs \
 		registry.undistro.io/dockerhub/jnorwood/helm-docs:v1.8.1 \
 		helm-docs -s=file

--- a/pkg/discovery/cluster_labels.go
+++ b/pkg/discovery/cluster_labels.go
@@ -1,6 +1,9 @@
 package discovery
 
-const RegionLabel = "topology.kubernetes.io/region"
+const (
+	RegionLabel     = "topology.kubernetes.io/region"
+	MasterNodeLabel = "node-role.kubernetes.io/master"
+)
 
 var ClusterSourcePrefixes = map[string]string{
 	"cloud.google.com/gke":   "gcp",

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -96,8 +96,9 @@ func (r *clusterDiscovery) Discover(ctx context.Context) (*ClusterInfo, error) {
 // labels on a node, returning the provider if the match succeeds and
 // "self-hosted" if it fails.
 func (r *clusterDiscovery) Provider(_ context.Context, node NodeInfo) (string, error) {
+	prov := "unknown"
 	match := false
-	prov := ""
+	hasmaster := false
 	for l, _ := range node.Labels {
 		for pref, p := range ClusterSourcePrefixes {
 			match = strings.HasPrefix(l, pref)
@@ -109,8 +110,11 @@ func (r *clusterDiscovery) Provider(_ context.Context, node NodeInfo) (string, e
 		if match {
 			break
 		}
+		if !hasmaster && l == MasterNodeLabel {
+			hasmaster = true
+		}
 	}
-	if !match {
+	if !match && hasmaster {
 		return "self-hosted", nil
 	}
 	return prov, nil

--- a/scripts/setup_region_label.sh
+++ b/scripts/setup_region_label.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+CLUSTER_REGION_LABEL=${CLUSTER_REGION_LABEL:-"topology.kubernetes.io/region=local"}
+
+for n in $(kubectl get nodes -o jsonpath='{.items[].metadata.name}'); do
+	kubectl get node $n -o jsonpath='{.metadata.labels}' 2> /dev/null \
+		| grep -q "${CLUSTER_REGION_LABEL%=*}"
+	if test $? -ne 0; then
+		kubectl label node $n "$CLUSTER_REGION_LABEL";
+	fi
+done


### PR DESCRIPTION
## Description
Changes:
	- Ensure a cluster node has the master label to be classified as
	  self-hosted;
	- Automatically add the region label with the "local" value on
	  virtual clusters like Kind and Minikube;
	- Make controller reconcile after errors with a 5 minute period;

The master label is: \<node-role.kubernetes.io/master\>

## How has this been tested?
Local installations

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/getupio-undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [x] My changes are covered by tests
