### PR TITLE
add job environment variables in worker container

### DIFF
--- a/pkg/plugins/cronjobs/cronjob.go
+++ b/pkg/plugins/cronjobs/cronjob.go
@@ -168,6 +168,24 @@ func (r *Mutator) workerEnv() []corev1.EnvVar {
 			Name:  "CLUSTER_ISSUES_NAMESPACE",
 			Value: r.Clusterscan.Namespace,
 		},
+		corev1.EnvVar{
+			Name: "JOB_NAME",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.labels['job-name']", APIVersion: "v1"},
+			},
+		},
+		corev1.EnvVar{
+			Name: "JOB_NAMESPACE",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace", APIVersion: "v1"},
+			},
+		},
+		corev1.EnvVar{
+			Name: "JOB_UID",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.labels['controller-uid']", APIVersion: "v1"},
+			},
+		},
 	)
 }
 


### PR DESCRIPTION
## Description
Add job environment variables in worker container.
That way, Worker can build ClusterIssue with Job as owner based on env variables only.

## Linked Issues
There is no linked issues

## How has this been tested?
Configuring a ClusterScan and see the environments variables available on Worker container:
```
DONE_DIR=/tmp/undistro-inspect/results
CLUSTER_NAME=harbor
CLUSTER_ISSUES_NAMESPACE=undistro-inspect
JOB_NAME=harbor-popeye-27549822
JOB_NAMESPACE=undistro-inspect
JOB_UID=3151882c-e95a-4bfd-9c79-b44f5b651bf5
```
There is enough to build an OwnerReference like this:
```yaml
  ownerReferences:
  - apiVersion: batch/v1
    blockOwnerDeletion: true
    controller: true
    kind: Job
    name: harbor-popeye-27549822                         # JOB_NAME env variable
    uid: 3151882c-e95a-4bfd-9c79-b44f5b651bf5    # JOB_UID env variable
```

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/getupio-undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [x] My changes are covered by tests
