### PR TITLE
add resourceVersion field in reconciler log

### DIFF
--- a/controllers/inspect/cluster_controller.go
+++ b/controllers/inspect/cluster_controller.go
@@ -46,10 +46,16 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		log.Error(err, "failed to fetch Cluster")
 		return ctrl.Result{RequeueAfter: 5 * time.Minute}, client.IgnoreNotFound(err)
 	}
+	log = log.WithValues("resourceVersion", cluster.ResourceVersion)
+	ctx = ctrllog.IntoContext(ctx, log)
+
+	defer func(t time.Time) {
+		log.Info(fmt.Sprintf("Cluster has been reconciled in %v", time.Since(t)))
+	}(time.Now())
 
 	err := r.reconcile(ctx, cluster)
 	if err := r.Status().Update(ctx, cluster); err != nil {
-		log.Error(err, "failed to update cluster status")
+		log.Error(err, "failed to update Cluster status")
 	}
 	return ctrl.Result{RequeueAfter: 5 * time.Minute}, err
 }

--- a/controllers/inspect/clusterscan_controller.go
+++ b/controllers/inspect/clusterscan_controller.go
@@ -62,6 +62,12 @@ func (r *ClusterScanReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		log.Error(err, "failed to fetch ClusterIssue")
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+	log = log.WithValues("resourceVersion", clusterscan.ResourceVersion)
+	ctx = ctrllog.IntoContext(ctx, log)
+
+	defer func(t time.Time) {
+		log.Info(fmt.Sprintf("ClusterScan has been reconciled in %v", time.Since(t)))
+	}(time.Now())
 
 	err := r.reconcile(ctx, clusterscan)
 	if err := r.Status().Update(ctx, clusterscan); err != nil {
@@ -84,7 +90,7 @@ func (r *ClusterScanReconciler) reconcile(ctx context.Context, clusterscan *v1al
 
 	if !cluster.Status.ConditionIsTrue(v1alpha1.ClusterReady) {
 		err := errors.New(fmt.Sprintf("the Cluster %s is not Ready", cluster.Name))
-		log.Error(err, "cluster is not ready")
+		log.Error(err, "Cluster is not ready")
 		clusterscan.SetReadyStatus(false, "ClusterNotReady", err.Error())
 		return err
 	}


### PR DESCRIPTION
## Description
add `resourceVersion` field in reconciler log

## Linked Issues
there is no linked issues

## How has this been tested?
Running the operator

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/getupio-undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [x] My changes are covered by tests
