### PR TITLE
Fix generic Popeye message bug

### DIFF
--- a/worker/report/popeye/parse.go
+++ b/worker/report/popeye/parse.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 
 	inspectv1a1 "github.com/getupio-undistro/inspect/apis/inspect/v1alpha1"
 )
@@ -19,7 +20,7 @@ func prepareIdAndMsg(msg string) (string, string, error) {
 	if len(s) != 3 {
 		return "", "", errors.New("Unable to split Popeye error code from message.")
 	}
-	if msg, ok := IssueIDtoGenericMsg[s[1]]; ok {
+	if msg, ok := IssueIDtoGenericMsg[s[1][strings.LastIndex(s[1], "-")+1:]]; ok {
 		return s[1], msg, nil
 	}
 	return s[1], s[2], nil


### PR DESCRIPTION
## Description
The \<prepareIdAndMsg\> function which was using an incorrect identifier
when checking for specific issue messages. This implements the correct
behavior.

## How has this been tested?
Through local executions.

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/getupio-undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [x] My changes are covered by tests