### PR TITLE
Change cluster age discovery mechanism

### DIFF
--- a/pkg/discovery/discovery_test.go
+++ b/pkg/discovery/discovery_test.go
@@ -3,7 +3,6 @@ package discovery
 import (
 	"reflect"
 	"testing"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -446,37 +445,4 @@ func TestRegion(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestOldestNodeTimestamp(t *testing.T) {
-	type args struct {
-		nodes []NodeInfo
-	}
-	tests := []struct {
-		name string
-		args args
-		want metav1.Time
-	}{
-		{
-			name: "OK",
-			args: args{nodes: []NodeInfo{
-				{CreationTimestamp: parseTime("2022-05-05T11:03:23Z")},
-				{CreationTimestamp: parseTime("2022-05-02T18:41:51Z")},
-				{CreationTimestamp: parseTime("2022-05-02T18:41:50Z")},
-			}},
-			want: parseTime("2022-05-02T18:41:50Z"),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := oldestNodeTimestamp(tt.args.nodes); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("oldestNodeTimestamp() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func parseTime(value string) metav1.Time {
-	tt, _ := time.Parse(time.RFC3339, value)
-	return metav1.NewTime(tt)
 }


### PR DESCRIPTION
## Description
Previously, the cluster age was set to that of the oldest node. This
commit makes the cluster age use the timestamp set on the \<kube-system\>
namespace.

The \<oldestNodeTimestamp\> function and its tests are removed, given it's
no longer used.

## How has this been tested?
By connecting to our Harbor EKS cluster and comparing its creation timestamp.

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/getupio-undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [x] My changes are covered by tests