### PR TITLE
Add <nil> check to cluster status fields

### DIFF
--- a/controllers/inspect/cluster_controller.go
+++ b/controllers/inspect/cluster_controller.go
@@ -121,12 +121,14 @@ func (r *ClusterReconciler) updateScanStatus(ctx context.Context, cluster *v1alp
 		return err
 	}
 
-	if cluster.Status.LastSuccessfulScanTime == nil && len(clusterScanList.Items) != 0 {
+	if cluster.Status.LastSuccessfulScanTime == nil && len(clusterScanList.Items) != 0 &&
+		clusterScanList.Items[0].Status.LastSuccessfulTime != nil {
 		cluster.Status.LastSuccessfulScanTime = &metav1.Time{
 			Time: clusterScanList.Items[0].Status.LastSuccessfulTime.Time,
 		}
 	}
-	if cluster.Status.NextScheduleScanTime == nil && len(clusterScanList.Items) != 0 {
+	if cluster.Status.NextScheduleScanTime == nil && len(clusterScanList.Items) != 0 &&
+		clusterScanList.Items[0].Status.NextScheduleTime != nil {
 		cluster.Status.NextScheduleScanTime = &metav1.Time{
 			Time: clusterScanList.Items[0].Status.NextScheduleTime.Time,
 		}


### PR DESCRIPTION
## Description
Check for \<nil\> pointer on initializing the \<NextScheduleScanTime\> and
\<LastSuccessfulScanTime\> \<Cluster\> status fields.

## How has this been tested?
By local executions on a virtual cluster.

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/getupio-undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [x] My changes are covered by tests