### PR TITLE
Fix scan env bug

### DIFF
--- a/pkg/plugins/cronjobs/cronjob.go
+++ b/pkg/plugins/cronjobs/cronjob.go
@@ -171,7 +171,7 @@ func (r *Mutator) workerEnv() []corev1.EnvVar {
 	return append(commonEnv,
 		corev1.EnvVar{
 			Name:  "CLUSTER_NAME",
-			Value: r.ClusterScan.Name,
+			Value: r.ClusterScan.Spec.ClusterRef.Name,
 		},
 		corev1.EnvVar{
 			Name:  "CLUSTER_ISSUES_NAMESPACE",


### PR DESCRIPTION
## Description
The clusterscan controller was setting the wrong value to the
\<CLUSTER_NAME\> variable. This commit sets the name of the cluster, as
specified on the \<ClusterRef\> field from the \<ClusterScan\>
specification.

Such variable is used to transmit the inspected cluster name to the
worker module.

## How has this been tested?
By local executions on a virtual cluster.

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/getupio-undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [x] My changes are covered by tests