### PR TITLE
Fix repeated cronjob name bug

### DIFF
--- a/controllers/inspect/clusterscan_controller.go
+++ b/controllers/inspect/clusterscan_controller.go
@@ -127,7 +127,7 @@ func (r *ClusterScanReconciler) reconcile(ctx context.Context, clusterscan *v1al
 			clusterscan.SetReadyStatus(false, "PluginFetchError", err.Error())
 			return err
 		}
-		cronJob := cronjobs.New(fmt.Sprintf("%s-%s", cluster.Name, plugin.Name), kubeconfigSecret.Namespace)
+		cronJob := cronjobs.New(fmt.Sprintf("%s-%s", clusterscan.Name, plugin.Name), kubeconfigSecret.Namespace)
 
 		cronJobMutator := &cronjobs.Mutator{
 			Scheme:             r.Scheme,


### PR DESCRIPTION
## Description
Prevent clusterscan controller from trying to create cronjobs with the
same name by using the \<ClusterScan\> name, instead of the \<Cluster\> one.

## How has this been tested?
By local executions on a virtual cluster.

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/getupio-undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [x] My changes are covered by tests