### PR TITLE
Parameterize setup script scan schedule

### DIFF
--- a/hack/scripts/setup_zora_view.sh
+++ b/hack/scripts/setup_zora_view.sh
@@ -6,6 +6,7 @@ CLUSTER_NS=${CLUSTER_NS:-"zora-system"}
 KCONFIG_PATH=${KCONFIG_PATH:-"zora_view_kubeconfig.yaml"}
 KCONFIG_SECRET_NAME=${KCONFIG_SECRET_NAME:-"$CLUSTER_NAME-kubeconfig"}
 ENABLE_CLUSTER_SCAN=${ENABLE_CLUSTER_SCAN:-0}
+CLUSTER_SCAN_CRON_SCHEDULE=${CLUSTER_SCAN_CRON_SCHEDULE:-'*/2 * * * *'}
 
 setup_namespaces() {
 	if ! kubectl get namespace $CLUSTER_NS > /dev/null 2>&1; then
@@ -47,7 +48,7 @@ metadata:
 spec:
   clusterRef:
     name: $CLUSTER_NAME
-  schedule: "*/2 * * * *"
+  schedule: "$CLUSTER_SCAN_CRON_SCHEDULE"
 EOF
 }
 


### PR DESCRIPTION
## Description
The current scan schedule on the setup scripts is hard coded. This
commit allows it be customized through the variable
\<CLUSTER_SCAN_CRON_SCHEDULE\>.

## How has this been tested?
By invoking the scripts.

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/getupio-undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [x] My changes are covered by tests
