### PR TITLE
fix clustes resources status field

### DIFF
--- a/apis/zora/v1alpha1/cluster_types.go
+++ b/apis/zora/v1alpha1/cluster_types.go
@@ -66,6 +66,7 @@ type ClusterStatus struct {
 
 // SetResources format and fill temporary fields about resources
 func (in *ClusterStatus) SetResources(res discovery.ClusterResources) {
+	in.Resources = res.DeepCopy()
 	if m, found := res[corev1.ResourceMemory]; found {
 		in.MemoryAvailable = formats.Memory(m.Available)
 		in.MemoryUsage = formats.MemoryUsage(m.Usage, m.UsagePercentage)


### PR DESCRIPTION
## Description
Filling `resources` field of Cluster status.

## Linked Issues
There is no linked issues

## How has this been tested?
See https://zora-hml.undistro.io/

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/getupio-undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [x] My changes are covered by tests
