### PR TITLE
Fix severity enum of ClusterIssue

### DIFF
--- a/apis/zora/v1alpha1/clusterissue_types.go
+++ b/apis/zora/v1alpha1/clusterissue_types.go
@@ -4,7 +4,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-//+kubebuilder:validation:Enum=None;Low;Medium;High
+//+kubebuilder:validation:Enum=Unknown;Low;Medium;High
 
 type ClusterIssueSeverity string
 

--- a/charts/zora/crds/zora.undistro.io_clusterissues.yaml
+++ b/charts/zora/crds/zora.undistro.io_clusterissues.yaml
@@ -76,7 +76,7 @@ spec:
                 type: object
               severity:
                 enum:
-                - None
+                - Unknown
                 - Low
                 - Medium
                 - High

--- a/config/crd/bases/zora.undistro.io_clusterissues.yaml
+++ b/config/crd/bases/zora.undistro.io_clusterissues.yaml
@@ -76,7 +76,7 @@ spec:
                 type: object
               severity:
                 enum:
-                - None
+                - Unknown
                 - Low
                 - Medium
                 - High


### PR DESCRIPTION
## Description
Fix enum of severity field in ClusterIssue CRD.

## How has this been tested?
Error in HML:
```
$ klo teste2-doks-j254qyl9-2-popeye-27658800-bjn5h
Defaulted container "worker" out of: worker, popeye
2022-08-03T12:00:03Z	INFO	worker	Starting worker
2022-08-03T12:00:07Z	INFO	worker	Worker crashed
panic: Failed to create issues: Failed to create <ClusterIssue> instance on cluster <teste2-doks-j254qyl9-2>: ClusterIssue.zora.undistro.io "teste2-doks-j254qyl9-2-pop-406-d60ee512e34f" is invalid: spec.severity: Unsupported value: "Unknown": supported values: "None", "Low", "Medium", "High"

goroutine 1 [running]:
main.main()
	/workspace/worker/main.go:25 +0x215
```

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/getupio-undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [x] My changes are covered by tests
