### PR TITLE
fix nextScheduleTime sync and covering in unit tests

### DIFF
--- a/apis/zora/v1alpha1/clusterscan_types.go
+++ b/apis/zora/v1alpha1/clusterscan_types.go
@@ -103,6 +103,7 @@ func (in *ClusterScanStatus) GetPluginStatus(name string) *PluginScanStatus {
 func (in *ClusterScanStatus) SyncStatus() {
 	var names []string
 	var failed, active, complete int
+	in.NextScheduleTime = nil
 	for n, p := range in.Plugins {
 		names = append(names, n)
 		if in.LastScheduleTime == nil || in.LastScheduleTime.Before(p.LastScheduleTime) {


### PR DESCRIPTION
## Description
The field `nextScheduleTime` of `ClusterScan` was not being filled correctly.

## How has this been tested?
Running unit tests

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/getupio-undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [x] My changes are covered by tests
