### PR TITLE
return lastFinishedScanTime field instead of only lastSuccessfulScanTime

### DIFF
--- a/apis/zora/v1alpha1/clusterscan_types_test.go
+++ b/apis/zora/v1alpha1/clusterscan_types_test.go
@@ -285,7 +285,7 @@ func TestSyncStatus(t *testing.T) {
 				},
 				"kubescape": {
 					LastScheduleTime:   mustParseTime("2022-08-08T21:00:00Z"),
-					LastFinishedTime:   mustParseTime("2022-08-08T21:00:03Z"),
+					LastFinishedTime:   mustParseTime("2022-08-08T21:00:06Z"),
 					NextScheduleTime:   mustParseTime("2022-08-08T22:00:00Z"),
 					LastScanID:         "ce34e6fc-768d-49d0-91b5-65df89ed147d",
 					LastStatus:         string(batchv1.JobFailed),
@@ -295,7 +295,7 @@ func TestSyncStatus(t *testing.T) {
 			},
 			want: &ClusterScanStatus{
 				LastScheduleTime:   mustParseTime("2022-08-08T21:00:00Z"),
-				LastFinishedTime:   mustParseTime("2022-08-08T21:00:03Z"),
+				LastFinishedTime:   mustParseTime("2022-08-08T21:00:06Z"),
 				LastSuccessfulTime: mustParseTime("2022-08-08T21:00:03Z"),
 				NextScheduleTime:   mustParseTime("2022-08-08T22:00:00Z"),
 				LastFinishedStatus: string(batchv1.JobFailed),

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -144,6 +144,10 @@ components:
           type: string
           format: date-time
           example: "2022-06-14T17:30:11Z"
+        lastFinishedScanTime:
+          type: string
+          format: date-time
+          example: "2022-06-14T17:30:11Z"
         nextScheduleScanTime:
           type: string
           format: date-time

--- a/payloads/clusters.go
+++ b/payloads/clusters.go
@@ -36,6 +36,7 @@ type Cluster struct {
 	CreationTimestamp      metav1.Time       `json:"creationTimestamp"`
 	Issues                 []ResourcedIssue  `json:"issues"`
 	LastSuccessfulScanTime *metav1.Time      `json:"lastSuccessfulScanTime"`
+	LastFinishedScanTime   *metav1.Time      `json:"lastFinishedScanTime"`
 	NextScheduleScanTime   *metav1.Time      `json:"nextScheduleScanTime"`
 }
 
@@ -108,6 +109,9 @@ func NewCluster(cluster v1alpha1.Cluster, scans []v1alpha1.ClusterScan) Cluster 
 		// last and next scan time
 		if cl.LastSuccessfulScanTime == nil || cl.LastSuccessfulScanTime.Before(cs.Status.LastSuccessfulTime) {
 			cl.LastSuccessfulScanTime = cs.Status.LastSuccessfulTime
+		}
+		if cl.LastFinishedScanTime == nil || cl.LastFinishedScanTime.Before(cs.Status.LastFinishedTime) {
+			cl.LastFinishedScanTime = cs.Status.LastFinishedTime
 		}
 		if cl.NextScheduleScanTime == nil || cs.Status.NextScheduleTime.Before(cl.NextScheduleScanTime) {
 			cl.NextScheduleScanTime = cs.Status.NextScheduleTime

--- a/payloads/testdata/payload/1.json
+++ b/payloads/testdata/payload/1.json
@@ -31,5 +31,6 @@
   },
   "totalIssues": 62,
   "lastSuccessfulScanTime": "2022-08-04T21:47:00Z",
+  "lastFinishedScanTime": "2022-08-04T21:47:00Z",
   "nextScheduleScanTime": "2022-08-04T23:45:00Z"
 }

--- a/payloads/testdata/payload/2.json
+++ b/payloads/testdata/payload/2.json
@@ -16,5 +16,6 @@
     "status": "failed",
     "message": "Plugins <kubescape> and <popeye> failed in the last scan of ClusterScan <myclusterscan>"
   },
-  "nextScheduleScanTime": "2022-08-04T23:45:00Z"
+  "nextScheduleScanTime": "2022-08-04T23:45:00Z",
+  "lastFinishedScanTime": "2022-08-04T22:47:00Z"
 }

--- a/payloads/testdata/payload/4.json
+++ b/payloads/testdata/payload/4.json
@@ -31,5 +31,6 @@
   },
   "totalIssues": null,
   "lastSuccessfulScanTime": "2022-08-04T21:47:00Z",
-  "nextScheduleScanTime": "2022-08-04T23:45:00Z"
+  "nextScheduleScanTime": "2022-08-04T23:45:00Z",
+  "lastFinishedScanTime": "2022-08-04T22:46:00Z"
 }

--- a/payloads/testdata/payload/5.json
+++ b/payloads/testdata/payload/5.json
@@ -31,5 +31,6 @@
   },
   "totalIssues": 62,
   "lastSuccessfulScanTime": "2022-08-04T22:46:00Z",
-  "nextScheduleScanTime": "2022-08-04T23:45:00Z"
+  "nextScheduleScanTime": "2022-08-04T23:45:00Z",
+  "lastFinishedScanTime": "2022-08-04T22:46:00Z"
 }

--- a/payloads/testdata/payload/6.json
+++ b/payloads/testdata/payload/6.json
@@ -29,5 +29,6 @@
   },
   "totalIssues": 62,
   "lastSuccessfulScanTime": "2022-08-04T22:47:00Z",
-  "nextScheduleScanTime": "2022-08-04T23:45:00Z"
+  "nextScheduleScanTime": "2022-08-04T23:45:00Z",
+  "lastFinishedScanTime": "2022-08-04T22:47:00Z"
 }

--- a/payloads/testdata/payload/7.json
+++ b/payloads/testdata/payload/7.json
@@ -31,5 +31,6 @@
   },
   "totalIssues": null,
   "lastSuccessfulScanTime": "2022-08-08T21:00:03Z",
-  "nextScheduleScanTime": "2022-08-08T22:00:00Z"
+  "nextScheduleScanTime": "2022-08-08T22:00:00Z",
+  "lastFinishedScanTime": "2022-08-08T21:00:03Z"
 }

--- a/payloads/testdata/payload/9.json
+++ b/payloads/testdata/payload/9.json
@@ -31,5 +31,6 @@
   },
   "totalIssues": 124,
   "lastSuccessfulScanTime": "2022-08-04T22:47:00Z",
-  "nextScheduleScanTime": "2022-08-04T23:45:00Z"
+  "nextScheduleScanTime": "2022-08-04T23:45:00Z",
+  "lastFinishedScanTime": "2022-08-04T22:47:00Z"
 }


### PR DESCRIPTION
## Description
return `lastFinishedScanTime` field instead of only `lastSuccessfulScanTime` to solve when a Cluster never had a successful scan.
![image](https://user-images.githubusercontent.com/16636449/184414243-f724cd12-8c6c-4207-89d2-f0ce8df1b1e4.png)

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/getupio-undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [x] My changes are covered by tests
