### PR TITLE
Fix <clientset-gen> target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ generate: controller-gen ## Generate clientset and code containing DeepCopy, Dee
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 clientset-gen: ## Generate clientset
+	@rm -r $(PROJECT_ROOT)/pkg/clientset || echo -n
 	@docker run -i --rm \
 		-v $(PWD):/go/src/$(PROJECT_PACKAGE) \
 		-e PROJECT_PACKAGE=$(PROJECT_PACKAGE) \


### PR DESCRIPTION
## Description
The \<clientset-gen\> make target has a bug in which previous generated
clients are not removed in synchrony with their annotations. For
example:

		// Cluster is the Schema for the clusters API
	-	//+genclient
	-	//+genclient:onlyVerbs=list,get
	-	//+genclient:noStatus
		type Cluster struct {
			metav1.TypeMeta   `json:",inline"`

In case the \<genclient\> annotation were removed from the \<Cluster\>
struct, its previous implementation of the K8s clientset interfaces,
such as:

	type ClusterInterface interface {
		Get(ctx context.Context, name string, opts v1.GetOptions) (*v1alpha1.Cluster, error)
		List(ctx context.Context, opts v1.ListOptions) (*v1alpha1.ClusterList, error)
		ClusterExpansion
	}

... would remain in the clienset.

This commit removes the directory \<pkg/clientset\> prior to generation,
ensuring only annotated fields will have clients generated.

## How has this been tested?
With multiple executions of the target, wherefrom the \<genclient\> annotation
was removed from some of the API types.

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/getupio-undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [x] My changes are covered by tests
