### PR TITLE
Remove unused workflow variable

### DIFF
--- a/.github/workflows/docker-push.yaml
+++ b/.github/workflows/docker-push.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Push server
         run: IMG=$REPO/zora/server:$GITHUB_REF_NAME make docker-push
       - name: Push worker
-        run: IMG=$REPO/library/worker:$GITHUB_REF_NAME DOCKERFILE=Dockerfile.worker make docker-push
+        run: IMG=$REPO/library/worker:$GITHUB_REF_NAME make docker-push
 
       - name: Registry logout
         run: docker logout


### PR DESCRIPTION
## Description
The \<docker-push\> workflow sends Docker images to Zora's registry
through a Make target of the same name. Such target doesn't requires the
\<DOCKERFILE\> variable.

This commit removes that variable from the workflow target invokation.

## How has this been tested?
By running the \<docker-push\> target.

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/getupio-undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [x] My changes are covered by tests
