### PR TITLE
Simplify clientset generator fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ generate: controller-gen ## Generate clientset and code containing DeepCopy, Dee
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 clientset-gen: ## Generate clientset
-	@rm -r $(PROJECT_ROOT)/pkg/clientset || echo -n
+	@rm -r pkg/clientset || echo -n
 	@docker run -i --rm \
 		-v $(PWD):/go/src/$(PROJECT_PACKAGE) \
 		-e PROJECT_PACKAGE=$(PROJECT_PACKAGE) \


### PR DESCRIPTION
## Description

Remove the unused \<PROJECT_ROOT\> variable from the \<clientset-gen\>
target. The Makefile will already execute from such directory.

## How has this been tested?
With multiple executions of the target, wherefrom the \<genclient\> annotation
was removed from some of the API types.


## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/getupio-undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [x] My changes are covered by tests
