### PR TITLE
Fix plugin issue count

### DIFF
--- a/controllers/zora/clusterscan_controller.go
+++ b/controllers/zora/clusterscan_controller.go
@@ -202,7 +202,10 @@ func (r *ClusterScanReconciler) reconcile(ctx context.Context, clusterscan *v1al
 			issc[i.Labels[v1alpha1.LabelPlugin]]++
 		}
 		for p, c := range issc {
-			clusterscan.Status.Plugins[p].IssueCount = &c
+			if clusterscan.Status.Plugins[p].IssueCount == nil {
+				clusterscan.Status.Plugins[p].IssueCount = new(int)
+			}
+			*clusterscan.Status.Plugins[p].IssueCount = c
 		}
 		clusterscan.Status.TotalIssues = pointer.Int(len(issues))
 	}


### PR DESCRIPTION
## Description
There's a bug in the \<ClusterScan\> controller where the \<IssueCount\> field from
all instances of the \<PluginScanStatus\> struct within the \<Plugins\> map were
given the same pointer, thus carrying the same value, what appeared as an
incorrect sum when checking each plugin's issue count.

This is fixed in this commit.

## How has this been tested?
With local deployments on a virtual cluster pointing to the Hml cluster where
the bug was discovered and go-test as well.

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/getupio-undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [x] My changes are covered by tests
