### PR TITLE
Adapt Hml workflow to private UI repo

### DIFF
--- a/.github/workflows/hml.yaml
+++ b/.github/workflows/hml.yaml
@@ -48,12 +48,14 @@ jobs:
         run: |
           helm upgrade --install zora undistro/zora \
             -f charts/zora/values-hml.yaml \
+            --set imageCredentials.create=true \
             --set imageCredentials.username='${{ secrets.REGISTRY_USERNAME }}' \
             --set imageCredentials.password='${{ secrets.REGISTRY_PASSWORD }}' \
             --set operator.image.tag=$GITHUB_REF_NAME \
             --set server.image.tag=$GITHUB_REF_NAME \
             --set scan.worker.image.tag=$GITHUB_REF_NAME \
             --set ui.image.tag=$UI_IMAGE_TAG \
+            --set ui.image.repository=registry.undistro.io/zora/ui \
             --version $CHART_VERSION \
             --namespace zora-system \
             --create-namespace \
@@ -67,12 +69,14 @@ jobs:
         run: |
           helm upgrade --install zora undistro/zora \
             -f charts/zora/values-hml.yaml \
+            --set imageCredentials.create=true \
             --set imageCredentials.username='${{ secrets.REGISTRY_USERNAME }}' \
             --set imageCredentials.password='${{ secrets.REGISTRY_PASSWORD }}' \
             --set operator.image.tag=$GITHUB_REF_NAME \
             --set server.image.tag=$GITHUB_REF_NAME \
             --set scan.worker.image.tag=$GITHUB_REF_NAME \
             --set ui.image.tag=$UI_IMAGE_TAG \
+            --set ui.image.repository=registry.undistro.io/zora/ui \
             --version $CHART_VERSION \
             --namespace zora-system \
             --create-namespace \


### PR DESCRIPTION
## Description
The Chart has been changed to default to public images on version 0.3.7,
as part of the open sourcing effort, however, the UI will remain private.

This commit makes Github's Hml workflow use Docker images from Zora's
private repository.

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/getupio-undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [x] My changes are covered by tests
