### PR TITLE
fix install docs

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -16,9 +16,6 @@ helm upgrade --install zora undistro/zora \
   --create-namespace --wait
 ```
 
-!!! warning
-    `<USERNAME>` and `<PASSWORD>` must be replaced with your credentials.
-
 These commands deploy Zora to the Kubernetes cluster.
 [This section](helm-chart.md) lists the parameters
 that can be configured during installation.


### PR DESCRIPTION
## Description
Remove warning about credentials from docs at install steps

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/getupio-undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [ ] My changes are covered by tests
