### PR TITLE
Get only issues from last scans

### DIFF
--- a/charts/zora/Chart.yaml
+++ b/charts/zora/Chart.yaml
@@ -22,13 +22,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.8
+version: 0.3.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.3.8"
+appVersion: "v0.3.9"
 
 sources:
   - https://github.com/undistro/zora

--- a/charts/zora/README.md
+++ b/charts/zora/README.md
@@ -1,6 +1,6 @@
 # Zora Helm Chart
 
-![Version: 0.3.8](https://img.shields.io/badge/Version-0.3.8-informational?style=flat-square&color=38C794) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square&color=38C794) ![AppVersion: v0.3.8](https://img.shields.io/badge/AppVersion-v0.3.8-informational?style=flat-square&color=38C794)
+![Version: 0.3.9](https://img.shields.io/badge/Version-0.3.9-informational?style=flat-square&color=38C794) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square&color=38C794) ![AppVersion: v0.3.9](https://img.shields.io/badge/AppVersion-v0.3.9-informational?style=flat-square&color=38C794)
 
 Zora scans multiple Kubernetes clusters and reports potential issues.
 
@@ -12,7 +12,7 @@ To install the chart with the release name `zora`:
 helm repo add undistro https://registry.undistro.io/chartrepo/library
 helm upgrade --install zora undistro/zora \
   -n zora-system \
-  --version 0.3.8 \
+  --version 0.3.9 \
   --create-namespace --wait
 ```
 

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&defaultPluginsNamespace, "default-plugins-namespace", "zora-system", "The namespace of default plugins")
 	flag.StringVar(&defaultPluginsNames, "default-plugins-names", "popeye", "Comma separated list of default plugins")
-	flag.StringVar(&workerImage, "worker-image", "registry.undistro.io/library/zora-worker:v0.3.8", "Docker image name of Worker container")
+	flag.StringVar(&workerImage, "worker-image", "registry.undistro.io/library/zora-worker:v0.3.9", "Docker image name of Worker container")
 	flag.StringVar(&cronJobClusterRoleBinding, "cronjob-clusterrolebinding-name", "zora-plugins", "Name of ClusterRoleBinding to append CronJob ServiceAccounts")
 	flag.StringVar(&cronJobServiceAccount, "cronjob-serviceaccount-name", "zora-plugins", "Name of ServiceAccount to be configured, appended to ClusterRoleBinding and used by CronJobs")
 


### PR DESCRIPTION
## Description
Get only issues from last scans

## How has this been tested?
When an issue no longer appears on a scan, it was being returned in /issues endpoint

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [x] My changes are covered by tests
