### PR TITLE
Adapt <manifests> target to license headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ charts/zora/templates/operator/rbac.yaml: config/rbac/service_account.yaml \
 	@ for f in $^; do \
 		patch -Nfi "hack/patches/rbac/$$(basename -s '.yaml' $$f).patch" \
 			--no-backup-if-mismatch \
-			-p 1 -o - >> $@; \
+			-p 1 -o - | sed '/#/{N; d}' >> $@; \
 		echo "---" >> $@; \
 	done
 
@@ -50,7 +50,7 @@ manifest-consitency: charts/zora/templates/operator/rbac.yaml \
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 	@cp -r config/crd/bases/*.yaml charts/zora/crds/
-	$(MAKE) manifest-consitency
+	$(MAKE) manifest-consitency license
 
 generate: controller-gen ## Generate clientset and code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."

--- a/hack/patches/rbac/service_account.patch
+++ b/hack/patches/rbac/service_account.patch
@@ -1,7 +1,7 @@
 --- a/config/rbac/service_account.yaml	2022-04-12 17:43:03.730424686 -0300
 +++ b/config/rbac/service_account.yaml	2022-08-17 15:54:39.134889137 -0300
 @@ -1 +1,2 @@
-+{{- if .Values.operator.rbac.serviceAccount.create -}}
++{{ if .Values.operator.rbac.serviceAccount.create -}}
  apiVersion: v1
 @@ -3,3 +4,10 @@
  metadata:


### PR DESCRIPTION
## Description
Changes:
- Prevent the Chart operator RBAC file from having multiple license sections;
- Prevent such Chart file from trimming topmost whitespace;
- Make Kubebuilder generated files have the license header;

The RBAC file in question is \<charts/zora/templates/operator/rbac.yaml\>, which is generated by the \<manifest-consistency\> target according to the Kubebuilder generated RBAC files.

## How has this been tested?
Through Make calls and Helm templating.

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [x] My changes are covered by tests
