### PR TITLE
Fix target cluster doc

### DIFF
--- a/docs/target-cluster.md
+++ b/docs/target-cluster.md
@@ -13,12 +13,12 @@ A [script](https://zora.undistro.io/targetcluster.sh) is available to prepare a 
 The target cluster context can be set by exporting the `CONTEXT` variable or switching via `kubectl`, before running the script:
 
 ```shel
-CONTEXT=my-target-cluster curl -qL https://zora.undistro.io/targetcluster.sh | sh
+curl -q https://zora.undistro.io/targetcluster.sh | CONTEXT=<TARGET_CONTEXT> sh
 ```
 or
 ```shel
-kubectl config use-context my-target-cluster
-curl -qL https://zora.undistro.io/targetcluster.sh | sh
+kubectl config use-context <TARGET_CONTEXT>
+curl -q https://zora.undistro.io/targetcluster.sh | sh
 ```
 
 By default, the generated kubeconfig will be named as your current Kubernetes context suffixed with `-kubeconfig.yaml`.


### PR DESCRIPTION
## Description

Changes:
- Pass the \<CONTEXT\> variable to the shell instead of to Curl;
- Remove superfluous follow redirect Curl flag;
- Use user input syntax in the \<CONTEXT\> variable attribution;


## How has this been tested?
By rendering the documentation.

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [x] My changes are covered by tests
