### PR TITLE
Notify SaaS when the helm release is installed

### DIFF
--- a/charts/zora/templates/saas/install.yaml
+++ b/charts/zora/templates/saas/install.yaml
@@ -1,0 +1,51 @@
+# Copyright 2022 Undistro Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{ if .Values.saas.accountID }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "zora.fullname" . }}-saas-install-hook"
+  labels:
+    {{- include "zora.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  automountServiceAccountToken: false
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+  containers:
+    - name: curl
+      image: registry.undistro.io/dockerhub/radial/busyboxplus:curl
+      command:
+        - sh
+        - -xc
+        - |
+          curl -kfsS -X POST '{{ tpl .Values.saas.installHookURL . }}' \
+            -H 'content-type: application/json' \
+            -d '{{ toJson (dict
+              "kubeVersion" .Capabilities.KubeVersion.GitVersion
+              "chartVersion" .Chart.Version
+              "appVersion" .Chart.AppVersion
+              "release" .Release.Name
+              "namespace" .Release.Namespace
+              "revision" .Release.Revision) }}'
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+  restartPolicy: Never
+{{- end }}

--- a/charts/zora/values.yaml
+++ b/charts/zora/values.yaml
@@ -355,3 +355,8 @@ scan:
         repository: registry.undistro.io/quay/armosec/kubescape
         # -- kubescape plugin image tag
         tag: v2.0.163
+
+saas:
+  accountID: ""
+  server: "https://cloud.undistro.io"
+  installHookURL: "{{.Values.saas.server}}/api/v1/accounts/{{.Values.saas.accountID}}/helmreleases"


### PR DESCRIPTION
## Description
Notify SaaS when the helm release is installed

## How has this been tested?
- `kind create cluster`
- `helm upgrade --install zora zora/ --set saas.accountID=123 --wait`
- `kubectl logs zora-saas-install-hook` Here we can see the request for SaaS


## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [ ] I have documented my code (if applicable)
- [ ] My changes are covered by tests
