### PR TITLE
Cluster saas send

### DIFF
--- a/controllers/zora/cluster_controller.go
+++ b/controllers/zora/cluster_controller.go
@@ -88,7 +88,9 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 		clus := payloads.NewClusterSlice([]v1alpha1.Cluster{*cluster}, cslist.Items)
 		if len(clus) == 1 {
-			if err := r.Send(clus[0].Reader()); err != nil {
+			if ior, err := clus[0].Reader(); err != nil {
+				log.Error(err, "Unable to create <io.Reader> from cluster")
+			} else if err := r.Send(ior); err != nil {
 				log.Error(err, "Unable to complete transfer")
 			}
 		}

--- a/controllers/zora/cluster_controller.go
+++ b/controllers/zora/cluster_controller.go
@@ -17,11 +17,13 @@ package zora
 import (
 	"context"
 	"fmt"
+	"io"
 	"reflect"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
@@ -34,6 +36,7 @@ import (
 	"github.com/undistro/zora/apis/zora/v1alpha1"
 	"github.com/undistro/zora/pkg/discovery"
 	"github.com/undistro/zora/pkg/kubeconfig"
+	payloads "github.com/undistro/zora/pkg/payloads/v1alpha1"
 )
 
 // ClusterReconciler reconciles a Cluster object
@@ -42,21 +45,24 @@ type ClusterReconciler struct {
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
 	Config   *rest.Config
+	Send     func(io.Reader) error
 }
 
 //+kubebuilder:rbac:groups=zora.undistro.io,resources=clusters,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=zora.undistro.io,resources=clusters/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=zora.undistro.io,resources=clusters/finalizers,verbs=update
+//+kubebuilder:rbac:groups=zora.undistro.io,resources=clusterscans,verbs=list
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	var err error
 	log := ctrllog.FromContext(ctx)
 
 	cluster := &v1alpha1.Cluster{}
-	if err := r.Get(ctx, req.NamespacedName, cluster); err != nil {
-		return ctrl.Result{RequeueAfter: 5 * time.Minute}, client.IgnoreNotFound(err)
+	if err = r.Get(ctx, req.NamespacedName, cluster); client.IgnoreNotFound(err) != nil {
+		return ctrl.Result{RequeueAfter: 5 * time.Minute}, err
 	}
 	log = log.WithValues("resourceVersion", cluster.ResourceVersion)
 	ctx = ctrllog.IntoContext(ctx, log)
@@ -65,9 +71,27 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		log.Info(fmt.Sprintf("Cluster has been reconciled in %v", time.Since(t)))
 	}(time.Now())
 
-	err := r.reconcile(ctx, cluster)
-	if err := r.Status().Update(ctx, cluster); err != nil {
-		log.Error(err, "failed to update Cluster status")
+	if err == nil {
+		err = r.reconcile(ctx, cluster)
+		if err := r.Status().Update(ctx, cluster); err != nil {
+			log.Error(err, "failed to update Cluster status")
+		}
+	}
+
+	if r.Send != nil {
+		cslist := &v1alpha1.ClusterScanList{}
+		if err := r.List(ctx, cslist, &client.ListOptions{
+			Namespace:     cluster.Namespace,
+			FieldSelector: fields.OneTermEqualSelector("spec.clusterRef.name", cluster.Name),
+		}); client.IgnoreNotFound(err) != nil {
+			log.Error(err, "Unable to fetch scan list")
+		}
+		clus := payloads.NewClusterSlice([]v1alpha1.Cluster{*cluster}, cslist.Items)
+		if len(clus) == 1 {
+			if err := r.Send(clus[0].Reader()); err != nil {
+				log.Error(err, "Unable to complete transfer")
+			}
+		}
 	}
 	return ctrl.Result{RequeueAfter: 5 * time.Minute}, err
 }
@@ -140,6 +164,17 @@ func (r *ClusterReconciler) setStatusAndCreateEvent(cluster *v1alpha1.Cluster, s
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(),
+		&v1alpha1.ClusterScan{},
+		"spec.clusterRef.name",
+		func(o client.Object) []string {
+			cs := o.(*v1alpha1.ClusterScan)
+			return []string{cs.Spec.ClusterRef.Name}
+		},
+	); err != nil {
+		return err
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.Cluster{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Complete(r)

--- a/controllers/zora/saas_controller.go
+++ b/controllers/zora/saas_controller.go
@@ -101,13 +101,23 @@ func (r *SaasReconciler) reconcile(ctx context.Context, clist *v1alpha1.ClusterL
 	issues := payloads.NewIssues(cilist.Items)
 	log.Info(fmt.Sprintf("Sending %d issues", len(issues)))
 	for _, bod := range issues {
-		sendf(bod.Reader())
+		ior, err := bod.Reader()
+		if err != nil {
+			log.Error(err, "Unable to create <io.Reader> from issue")
+			continue
+		}
+		sendf(ior)
 	}
 
 	clusters := payloads.NewClusterSlice(clist.Items, cslist.Items)
 	log.Info(fmt.Sprintf("Sending %d clusters", len(clusters)))
 	for _, bod := range clusters {
-		sendf(bod.Reader())
+		ior, err := bod.Reader()
+		if err != nil {
+			log.Error(err, "Unable to create <io.Reader> from cluster")
+			continue
+		}
+		sendf(ior)
 	}
 
 	return nil

--- a/controllers/zora/saas_controller.go
+++ b/controllers/zora/saas_controller.go
@@ -92,7 +92,7 @@ func (r *SaasReconciler) reconcile(ctx context.Context, clist *v1alpha1.ClusterL
 	log := ctrllog.FromContext(ctx)
 
 	sendf := func(bod io.Reader) {
-		if err := r.send(bod); err != nil {
+		if err := r.Send(bod); err != nil {
 			log.Error(err, "Unable to complete transfer")
 		}
 		time.Sleep(100 * time.Millisecond)
@@ -101,19 +101,19 @@ func (r *SaasReconciler) reconcile(ctx context.Context, clist *v1alpha1.ClusterL
 	issues := payloads.NewIssues(cilist.Items)
 	log.Info(fmt.Sprintf("Sending %d issues", len(issues)))
 	for _, bod := range issues {
-		sendf(bod)
+		sendf(bod.Reader())
 	}
 
 	clusters := payloads.NewClusterSlice(clist.Items, cslist.Items)
 	log.Info(fmt.Sprintf("Sending %d clusters", len(clusters)))
 	for _, bod := range clusters {
-		sendf(bod)
+		sendf(bod.Reader())
 	}
 
 	return nil
 }
 
-func (r *SaasReconciler) send(bod io.Reader) error {
+func (r *SaasReconciler) Send(bod io.Reader) error {
 	req, err := http.NewRequest("POST", r.ServerAddr, bod)
 	if err != nil {
 		return err
@@ -129,7 +129,7 @@ func (r *SaasReconciler) send(bod io.Reader) error {
 	}
 	res.Body.Close()
 	if res.StatusCode != 200 {
-		return fmt.Errorf("Request returned status <%d %s>", res.StatusCode, res.Status)
+		return fmt.Errorf("Request returned status <%s>", res.Status)
 	}
 	return nil
 }

--- a/pkg/payloads/v1alpha1/clusters.go
+++ b/pkg/payloads/v1alpha1/clusters.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -250,10 +251,10 @@ func NewClusterSlice(carr []v1alpha1.Cluster, csarr []v1alpha1.ClusterScan) []Cl
 	return clusters
 }
 
-func (r Cluster) Read(b []byte) (int, error) {
+func (r Cluster) Reader() io.Reader {
 	jc, err := json.Marshal(r)
 	if err != nil {
-		return -1, err
+		return nil
 	}
-	return bytes.NewReader(jc).Read(b)
+	return bytes.NewReader(jc)
 }

--- a/pkg/payloads/v1alpha1/clusters.go
+++ b/pkg/payloads/v1alpha1/clusters.go
@@ -251,10 +251,10 @@ func NewClusterSlice(carr []v1alpha1.Cluster, csarr []v1alpha1.ClusterScan) []Cl
 	return clusters
 }
 
-func (r Cluster) Reader() io.Reader {
+func (r Cluster) Reader() (io.Reader, error) {
 	jc, err := json.Marshal(r)
 	if err != nil {
-		return nil
+		return nil, err
 	}
-	return bytes.NewReader(jc)
+	return bytes.NewReader(jc), nil
 }

--- a/pkg/payloads/v1alpha1/issues.go
+++ b/pkg/payloads/v1alpha1/issues.go
@@ -17,6 +17,7 @@ package v1alpha1
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 
 	"github.com/undistro/zora/apis/zora/v1alpha1"
 )
@@ -78,10 +79,10 @@ func NewIssues(clusterIssues []v1alpha1.ClusterIssue) []Issue {
 	return res
 }
 
-func (r Issue) Read(b []byte) (int, error) {
+func (r Issue) Reader() io.Reader {
 	jc, err := json.Marshal(r)
 	if err != nil {
-		return -1, err
+		return nil
 	}
-	return bytes.NewReader(jc).Read(b)
+	return bytes.NewReader(jc)
 }

--- a/pkg/payloads/v1alpha1/issues.go
+++ b/pkg/payloads/v1alpha1/issues.go
@@ -79,10 +79,10 @@ func NewIssues(clusterIssues []v1alpha1.ClusterIssue) []Issue {
 	return res
 }
 
-func (r Issue) Reader() io.Reader {
+func (r Issue) Reader() (io.Reader, error) {
 	jc, err := json.Marshal(r)
 	if err != nil {
-		return nil
+		return nil, err
 	}
-	return bytes.NewReader(jc)
+	return bytes.NewReader(jc), nil
 }


### PR DESCRIPTION
## Description
Changes:
- Export \<Saas\> controller \<send\> function;
- Make the \<Cluster\> controller communicate with the Saas server;
- Pass the \<Send\> function from \<SaasReconciler\> to the \<Cluster\>
  controller;
- Change controller instantiation order so to have the
  \<SaasReconciler\> in place first;
- Change \<io.Reader\> implementation of \<payloads\> types;

## How has this been tested?
With local deployments on a virtual cluster and go test.

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/getupio-undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [x] My changes are covered by tests
