### PR TITLE
Fix <targetcluster.sh> whitespace

### DIFF
--- a/docs/targetcluster.sh
+++ b/docs/targetcluster.sh
@@ -241,7 +241,7 @@ metadata:
   namespace: $CLUSTER_NS
 spec:
   kubeconfigRef:
-	name: $KCONFIG_SECRET_NAME 
+    name: $KCONFIG_SECRET_NAME
 EOF
 }
 


### PR DESCRIPTION
## Description
The target cluster setup script generates a sample \<Cluster\> manifest. The manifest however, had a tab character, what is not allowed by the Yaml spec. This commit replaces such character with spaces.

## How has this been tested?
By applying the manifest.

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/getupio-undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [x] My changes are covered by tests
