### PR TITLE
Cluster sample unique name

### DIFF
--- a/docs/target-cluster.md
+++ b/docs/target-cluster.md
@@ -49,8 +49,8 @@ A complete list of customizable environment variables can be seen on the table b
 | `CLUSTER_NS`				| Cluster namespace used on the manifest sample, defaults to the value of `SVC_ACCOUNT_NS` |
 | `CLUSTER_CA`				| Cluster Certificate Authority, extracted according to `CONTEXT` |
 | `CLUSTER_SERVER`			| Cluster server address, extracted according to `CONTEXT` |
-| `KCONFIG_NAME`			| Name of the generated kubeconfig, defaulting to the value of `CONTEXT` plus the string "-kubeconfig.yaml" |
-| `SAMPLE_MANIFEST_NAME` 	| Name of the `Cluster` manifest sample, defaults to `cluster_sample.yaml` |
+| `KCONFIG_NAME`			| Name of the generated kubeconfig, defaulting to the value of `CONTEXT` plus the string "_kubeconfig.yaml" |
+| `SAMPLE_MANIFEST_NAME` 	| Name of the `Cluster` manifest sample, defaults to `cluster_sample.yaml` plus the K8s context as prefix |
 
 The next instructions explain how to manually configure your target clusters.
 

--- a/docs/targetcluster.sh
+++ b/docs/targetcluster.sh
@@ -257,7 +257,7 @@ CONTEXT=${CONTEXT:-"$(get_current_context)"}
 setup_namespaces
 setup_svc_account
 
-if kubectl --context $CONTEXT version --short | awk '/Server/{if ($3 < "1.24.0") {exit 1}}'; then
+if kubectl --context $CONTEXT version --short 2> /dev/null | awk '/Server/{if ($3 < "1.24.0") {exit 1}}'; then
   setup_svc_account_secret
   TOKEN_NAME=${TOKEN_NAME:-"$SVC_ACCOUNT_SECRET_NAME"}
 else

--- a/docs/targetcluster.sh
+++ b/docs/targetcluster.sh
@@ -270,15 +270,15 @@ CLUSTER_CA=${CLUSTER_CA:-"$(get_cluster_ca)"}
 CLUSTER_SERVER=${CLUSTER_SERVER:-"$(get_cluster_server)"}
 
 CLUSTER_NS=${CLUSTER_NS:-$SVC_ACCOUNT_NS}
-KCONFIG_NAME=${KCONFIG_NAME:-"$CONTEXT-kubeconfig.yaml"}
+KCONFIG_NAME=${KCONFIG_NAME:-"${CONTEXT}_kubeconfig.yaml"}
 KCONFIG_SECRET_NAME=${KCONFIG_SECRET_NAME:-"$CLUSTER_NAME-kubeconfig"}
-SAMPLE_MANIFEST_NAME=${SAMPLE_MANIFEST_NAME:-"cluster_sample.yaml"}
+SAMPLE_MANIFEST_NAME=${SAMPLE_MANIFEST_NAME:-"${CONTEXT}_cluster_sample.yaml"}
 setup_cluster_role
 setup_cluster_role_binding
 create_kubeconfig
 
 echo
 show_generated_kconfig_name
-show_kconfig_creation_cmd
 create_cluster_sample
 show_cluster_sample_name
+show_kconfig_creation_cmd


### PR DESCRIPTION
## Description
Changes:
- Use a unique prefix for the default sample manifest name;
- Hide Kubectl warning about '--short' flag;
- Adjust docs to the unique sample manifest name;
- Show generated file names 1st on the script output;
- Standardize file name separator;

## How has this been tested?
With many executions on a virtual cluster.

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/getupio-undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [x] My changes are covered by tests
