### PR TITLE
Fix popeye scan in kubernetes 1.25

### DIFF
--- a/charts/zora/Chart.yaml
+++ b/charts/zora/Chart.yaml
@@ -17,7 +17,7 @@ name: zora
 description: Zora scans multiple Kubernetes clusters and reports potential issues.
 icon: https://zora-docs.undistro.io/assets/logo.png
 type: application
-version: 0.4.0
-appVersion: "v0.4.0"
+version: 0.4.1
+appVersion: "v0.4.1"
 sources:
   - https://github.com/undistro/zora

--- a/charts/zora/README.md
+++ b/charts/zora/README.md
@@ -1,6 +1,6 @@
 # Zora Helm Chart
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square&color=3CA9DD) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square&color=3CA9DD) ![AppVersion: v0.4.0](https://img.shields.io/badge/AppVersion-v0.4.0-informational?style=flat-square&color=3CA9DD)
+![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square&color=3CA9DD) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square&color=3CA9DD) ![AppVersion: v0.4.1](https://img.shields.io/badge/AppVersion-v0.4.1-informational?style=flat-square&color=3CA9DD)
 
 Zora scans multiple Kubernetes clusters and reports potential issues.
 
@@ -12,7 +12,7 @@ To install the chart with the release name `zora`:
 helm repo add undistro https://charts.undistro.io --force-update
 helm upgrade --install zora undistro/zora \
   -n zora-system \
-  --version 0.4.0 \
+  --version 0.4.1 \
   --create-namespace --wait
 ```
 

--- a/charts/zora/README.md
+++ b/charts/zora/README.md
@@ -96,7 +96,7 @@ The following table lists the configurable parameters of the Zora chart and thei
 | scan.defaultPlugins | list | `["popeye"]` | Names of the default plugins |
 | scan.plugins.popeye.enabled | bool | `true` |  |
 | scan.plugins.popeye.image.repository | string | `"ghcr.io/undistro/popeye"` | popeye plugin image repository |
-| scan.plugins.popeye.image.tag | string | `"v0.10.2"` | popeye plugin image tag |
+| scan.plugins.popeye.image.tag | string | `"nonroot"` | popeye plugin image tag |
 | scan.plugins.kubescape.enabled | bool | `false` |  |
 | scan.plugins.kubescape.image.repository | string | `"quay.io/armosec/kubescape"` | kubescape plugin image repository |
 | scan.plugins.kubescape.image.tag | string | `"v2.0.163"` | kubescape plugin image tag |

--- a/charts/zora/README.md
+++ b/charts/zora/README.md
@@ -95,8 +95,8 @@ The following table lists the configurable parameters of the Zora chart and thei
 | scan.worker.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
 | scan.defaultPlugins | list | `["popeye"]` | Names of the default plugins |
 | scan.plugins.popeye.enabled | bool | `true` |  |
-| scan.plugins.popeye.image.repository | string | `"derailed/popeye"` | popeye plugin image repository |
-| scan.plugins.popeye.image.tag | string | `"v0.10.0"` | popeye plugin image tag |
+| scan.plugins.popeye.image.repository | string | `"ghcr.io/undistro/popeye"` | popeye plugin image repository |
+| scan.plugins.popeye.image.tag | string | `"v0.10.2"` | popeye plugin image tag |
 | scan.plugins.kubescape.enabled | bool | `false` |  |
 | scan.plugins.kubescape.image.repository | string | `"quay.io/armosec/kubescape"` | kubescape plugin image repository |
 | scan.plugins.kubescape.image.tag | string | `"v2.0.163"` | kubescape plugin image tag |

--- a/charts/zora/templates/plugins/popeye.yaml
+++ b/charts/zora/templates/plugins/popeye.yaml
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{ if .Values.scan.plugins.popeye.enabled -}}
 apiVersion: zora.undistro.io/v1alpha1
 kind: Plugin
 metadata:
@@ -21,6 +20,10 @@ metadata:
     {{- include "zora.labels" . | nindent 4 }}
 spec:
   image: "{{ .Values.scan.plugins.popeye.image.repository }}:{{ .Values.scan.plugins.popeye.image.tag }}"
+  resources:
+    limits:
+      cpu: 500m
+      memory: 100Mi
   command:
     - /bin/sh
     - -c
@@ -46,4 +49,3 @@ spec:
       end=$(date +%s)
       echo "Scan has finished in $(($end-$start)) seconds with exit code $exitcode"
       exit $exitcode
-{{- end }}

--- a/charts/zora/values.yaml
+++ b/charts/zora/values.yaml
@@ -147,7 +147,7 @@ scan:
         # -- popeye plugin image repository
         repository: ghcr.io/undistro/popeye
         # -- popeye plugin image tag
-        tag: v0.10.2
+        tag: nonroot
     kubescape:
       enabled: false
       image:

--- a/charts/zora/values.yaml
+++ b/charts/zora/values.yaml
@@ -145,9 +145,9 @@ scan:
       enabled: true
       image:
         # -- popeye plugin image repository
-        repository: derailed/popeye
+        repository: ghcr.io/undistro/popeye
         # -- popeye plugin image tag
-        tag: v0.10.0
+        tag: v0.10.2
     kubescape:
       enabled: false
       image:

--- a/config/samples/zora_v1alpha1_plugin_popeye.yaml
+++ b/config/samples/zora_v1alpha1_plugin_popeye.yaml
@@ -18,6 +18,10 @@ metadata:
   name: popeye
 spec:
   image: ghcr.io/undistro/popeye:nonroot
+  resources:
+    limits:
+      cpu: 500m
+      memory: 100Mi
   command:
     - /bin/sh
     - -c

--- a/config/samples/zora_v1alpha1_plugin_popeye.yaml
+++ b/config/samples/zora_v1alpha1_plugin_popeye.yaml
@@ -17,7 +17,7 @@ kind: Plugin
 metadata:
   name: popeye
 spec:
-  image: derailed/popeye:v0.10.0
+  image: ghcr.io/undistro/popeye:v0.10.2
   command:
     - /bin/sh
     - -c

--- a/config/samples/zora_v1alpha1_plugin_popeye.yaml
+++ b/config/samples/zora_v1alpha1_plugin_popeye.yaml
@@ -17,7 +17,7 @@ kind: Plugin
 metadata:
   name: popeye
 spec:
-  image: ghcr.io/undistro/popeye:v0.10.2
+  image: ghcr.io/undistro/popeye:nonroot
   command:
     - /bin/sh
     - -c

--- a/hack/patches/popeye_plugin.patch
+++ b/hack/patches/popeye_plugin.patch
@@ -5,6 +5,6 @@
 +  labels:
 +    {{- include "zora.labels" . | nindent 4 }}
  spec:
--  image: derailed/popeye:v0.10.0
+-  image: ghcr.io/undistro/popeye:nonroot
 +  image: "{{ .Values.scan.plugins.popeye.image.repository }}:{{ .Values.scan.plugins.popeye.image.tag }}"
    command:

--- a/main.go
+++ b/main.go
@@ -21,9 +21,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/undistro/zora/pkg/saas"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+
+	"github.com/undistro/zora/pkg/saas"
 
 	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -69,7 +70,7 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&defaultPluginsNamespace, "default-plugins-namespace", "zora-system", "The namespace of default plugins")
 	flag.StringVar(&defaultPluginsNames, "default-plugins-names", "popeye", "Comma separated list of default plugins")
-	flag.StringVar(&workerImage, "worker-image", "ghcr.io/undistro/zora/worker:v0.4.0", "Docker image name of Worker container")
+	flag.StringVar(&workerImage, "worker-image", "ghcr.io/undistro/zora/worker:v0.4.1", "Docker image name of Worker container")
 	flag.StringVar(&cronJobClusterRoleBinding, "cronjob-clusterrolebinding-name", "zora-plugins", "Name of ClusterRoleBinding to append CronJob ServiceAccounts")
 	flag.StringVar(&cronJobServiceAccount, "cronjob-serviceaccount-name", "zora-plugins", "Name of ServiceAccount to be configured, appended to ClusterRoleBinding and used by CronJobs")
 	flag.StringVar(&saasWorkspaceID, "saas-workspace-id", "", "Your workspace ID in Zora SaaS")

--- a/pkg/plugins/cronjobs/cronjob.go
+++ b/pkg/plugins/cronjobs/cronjob.go
@@ -17,8 +17,6 @@ package cronjobs
 import (
 	"path/filepath"
 
-	"github.com/undistro/zora/apis/zora/v1alpha1"
-	"github.com/undistro/zora/pkg/kubeconfig"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,6 +24,9 @@ import (
 	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/undistro/zora/apis/zora/v1alpha1"
+	"github.com/undistro/zora/pkg/kubeconfig"
 )
 
 const (
@@ -117,6 +118,9 @@ func (r *Mutator) Mutate() controllerutil.MutateFn {
 				Name:         resultsVolumeName,
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
 			},
+		}
+		r.Existing.Spec.JobTemplate.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
+			RunAsNonRoot: pointer.Bool(true),
 		}
 
 		desiredContainers := map[string]corev1.Container{

--- a/pkg/plugins/cronjobs/cronjob.go
+++ b/pkg/plugins/cronjobs/cronjob.go
@@ -163,8 +163,9 @@ func (r *Mutator) workerContainer() corev1.Container {
 		Name:            workerContainerName,
 		Image:           r.WorkerImage,
 		Env:             r.workerEnv(),
-		ImagePullPolicy: corev1.PullIfNotPresent,
+		Resources:       r.Plugin.Spec.Resources,
 		VolumeMounts:    commonVolumeMounts,
+		ImagePullPolicy: corev1.PullIfNotPresent,
 	}
 }
 


### PR DESCRIPTION
## Description
When checking a cluster running kubernetes 1.25, popeye fails because the resource `policy/v1beta1/podsecuritypolicies` [has been removed](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.25.md#podsecuritypolicy-is-removed-pod-security-admission-graduates-to-stable).

While PR https://github.com/derailed/popeye/pull/239 is not merged, we can use a fork https://github.com/undistro/popeye.

Our fork uses a non-root user in popeye docker image. So we can set `securityContext.runAsNonRoot` to `true` in CronJobs.

## Linked Issues
- https://github.com/derailed/popeye/pull/239

## How has this been tested?
- Creating Clusters and ClusterScans

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [x] My changes are covered by tests
