### PR TITLE
Fix worker when popeye does not find the resource

### DIFF
--- a/charts/zora/Chart.yaml
+++ b/charts/zora/Chart.yaml
@@ -17,7 +17,7 @@ name: zora
 description: Zora scans multiple Kubernetes clusters and reports potential issues.
 icon: https://zora-docs.undistro.io/assets/logo.png
 type: application
-version: 0.4.1
-appVersion: "v0.4.1"
+version: 0.4.2
+appVersion: "v0.4.2"
 sources:
   - https://github.com/undistro/zora

--- a/charts/zora/README.md
+++ b/charts/zora/README.md
@@ -1,6 +1,6 @@
 # Zora Helm Chart
 
-![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square&color=3CA9DD) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square&color=3CA9DD) ![AppVersion: v0.4.1](https://img.shields.io/badge/AppVersion-v0.4.1-informational?style=flat-square&color=3CA9DD)
+![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square&color=3CA9DD) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square&color=3CA9DD) ![AppVersion: v0.4.2](https://img.shields.io/badge/AppVersion-v0.4.2-informational?style=flat-square&color=3CA9DD)
 
 Zora scans multiple Kubernetes clusters and reports potential issues.
 
@@ -12,7 +12,7 @@ To install the chart with the release name `zora`:
 helm repo add undistro https://charts.undistro.io --force-update
 helm upgrade --install zora undistro/zora \
   -n zora-system \
-  --version 0.4.1 \
+  --version 0.4.2 \
   --create-namespace --wait
 ```
 

--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&defaultPluginsNamespace, "default-plugins-namespace", "zora-system", "The namespace of default plugins")
 	flag.StringVar(&defaultPluginsNames, "default-plugins-names", "popeye", "Comma separated list of default plugins")
-	flag.StringVar(&workerImage, "worker-image", "ghcr.io/undistro/zora/worker:v0.4.1", "Docker image name of Worker container")
+	flag.StringVar(&workerImage, "worker-image", "ghcr.io/undistro/zora/worker:v0.4.2", "Docker image name of Worker container")
 	flag.StringVar(&cronJobClusterRoleBinding, "cronjob-clusterrolebinding-name", "zora-plugins", "Name of ClusterRoleBinding to append CronJob ServiceAccounts")
 	flag.StringVar(&cronJobServiceAccount, "cronjob-serviceaccount-name", "zora-plugins", "Name of ServiceAccount to be configured, appended to ClusterRoleBinding and used by CronJobs")
 	flag.StringVar(&saasWorkspaceID, "saas-workspace-id", "", "Your workspace ID in Zora SaaS")

--- a/worker/report/popeye/parse.go
+++ b/worker/report/popeye/parse.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+
 	zorav1a1 "github.com/undistro/zora/apis/zora/v1alpha1"
 )
 
@@ -51,6 +52,9 @@ func Parse(log logr.Logger, popr []byte) ([]*zorav1a1.ClusterIssueSpec, error) {
 	issuesmap := map[string]*zorav1a1.ClusterIssueSpec{}
 	for _, san := range r.Popeye.Sanitizers {
 		for typ, issues := range san.Issues {
+			if typ == "" {
+				continue
+			}
 			for _, iss := range issues {
 				id, msg, err := prepareIdAndMsg(iss.Message)
 				if err != nil {

--- a/worker/report/popeye/parse_test.go
+++ b/worker/report/popeye/parse_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
+
 	zorav1a1 "github.com/undistro/zora/apis/zora/v1alpha1"
 )
 
@@ -201,6 +202,24 @@ func TestParse(t *testing.T) {
 			testrepname: "testdata/test_report_4.json",
 			cispecs:     nil,
 			toerr:       true,
+		},
+		{
+			description: "Popeye report with error",
+			testrepname: "testdata/test_report_5.json",
+			cispecs: []*zorav1a1.ClusterIssueSpec{
+				{
+					ID:       "POP-712",
+					Message:  "Found only one master node",
+					Severity: "Low",
+					Category: "nodes",
+					Resources: map[string][]string{
+						"v1/nodes": {"kind-control-plane"},
+					},
+					TotalResources: 1,
+					Url:            "https://kubernetes.io/docs/concepts/overview/components/",
+				},
+			},
+			toerr: false,
 		},
 	}
 

--- a/worker/report/popeye/testdata/test_report_5.json
+++ b/worker/report/popeye/testdata/test_report_5.json
@@ -1,0 +1,50 @@
+{
+  "popeye": {
+    "score": 85,
+    "grade": "B",
+    "sanitizers": [
+      {
+        "sanitizer": "nodes",
+        "gvr": "v1/nodes",
+        "tally": {
+          "ok": 0,
+          "info": 1,
+          "warning": 0,
+          "error": 0,
+          "score": 100
+        },
+        "issues": {
+          "kind-control-plane": [
+            {
+              "group": "__root__",
+              "gvr": "v1/nodes",
+              "level": 1,
+              "message": "[POP-712] Found only one master node"
+            }
+          ]
+        }
+      },
+      {
+        "sanitizer": "poddisruptionbudgets",
+        "gvr": "policy/v1/poddisruptionbudgets",
+        "tally": {
+          "ok": 0,
+          "info": 0,
+          "warning": 0,
+          "error": 1,
+          "score": 0
+        },
+        "issues": {
+          "": [
+            {
+              "group": "__root__",
+              "gvr": "policy/v1/poddisruptionbudgets",
+              "level": 3,
+              "message": "the server could not find the requested resource"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Description
When popeye json report contain the following error:
```json
        "issues": {
          "": [
            {
              "group": "__root__",
              "gvr": "policy/v1/poddisruptionbudgets",
              "level": 3,
              "message": "the server could not find the requested resource"
            }
          ]
        }
```
it should be ignored.

## How has this been tested?
- make test
- scanning kubernetes 1.25 clusters

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [x] My changes are covered by tests
