### PR TITLE
Helm chart param for popeye resources

### DIFF
--- a/charts/zora/README.md
+++ b/charts/zora/README.md
@@ -96,6 +96,7 @@ The following table lists the configurable parameters of the Zora chart and thei
 | scan.defaultPlugins | list | `["popeye"]` | Names of the default plugins |
 | scan.plugins.popeye.enabled | bool | `true` |  |
 | scan.plugins.popeye.skipInternalResources | bool | `false` | Specifies whether the following resources should be skipped by `popeye` scans. 1. resources from `kube-system`, `kube-public` and `kube-node-lease` namespaces; 2. kubernetes system reserved RBAC (prefixed with `system:`); 3. `kube-root-ca.crt` configmaps; 4. `default` namespace; 5. `default` serviceaccounts; 6. Helm secrets (prefixed with `sh.helm.release`); 7. Zora components. See `popeye` configuration file that is used for this case: https://github.com/undistro/zora/blob/main/charts/zora/templates/plugins/popeye-config.yaml |
+| scan.plugins.popeye.resources | object | `{"limits":{"cpu":"500m","memory":"500Mi"},"requests":{"cpu":"250m","memory":"256Mi"}}` | [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) to add to `popeye` container |
 | scan.plugins.popeye.image.repository | string | `"ghcr.io/undistro/popeye"` | popeye plugin image repository |
 | scan.plugins.popeye.image.tag | string | `"nonroot"` | popeye plugin image tag |
 | scan.plugins.kubescape.enabled | bool | `false` |  |

--- a/charts/zora/templates/plugins/popeye.yaml
+++ b/charts/zora/templates/plugins/popeye.yaml
@@ -20,8 +20,10 @@ metadata:
     {{- include "zora.labels" . | nindent 4 }}
 spec:
   image: "{{ .Values.scan.plugins.popeye.image.repository }}:{{ .Values.scan.plugins.popeye.image.tag }}"
+  {{- if .Values.scan.plugins.popeye.resources }}
   resources:
     {{- toYaml .Values.scan.plugins.popeye.resources | nindent 4 }}
+  {{- end }}
 {{- if .Values.scan.plugins.popeye.skipInternalResources }}
   envFrom:
     - configMapRef:

--- a/charts/zora/templates/plugins/popeye.yaml
+++ b/charts/zora/templates/plugins/popeye.yaml
@@ -21,9 +21,7 @@ metadata:
 spec:
   image: "{{ .Values.scan.plugins.popeye.image.repository }}:{{ .Values.scan.plugins.popeye.image.tag }}"
   resources:
-    limits:
-      cpu: 500m
-      memory: 100Mi
+    {{- toYaml .Values.scan.plugins.popeye.resources | nindent 4 }}
 {{- if .Values.scan.plugins.popeye.skipInternalResources }}
   envFrom:
     - configMapRef:

--- a/charts/zora/values.yaml
+++ b/charts/zora/values.yaml
@@ -154,9 +154,12 @@ scan:
       # See `popeye` configuration file that is used for this case: https://github.com/undistro/zora/blob/main/charts/zora/templates/plugins/popeye-config.yaml
       skipInternalResources: false
       resources:
+        requests:
+          cpu: 250m
+          memory: 256Mi
         limits:
           cpu: 500m
-          memory: 300Mi
+          memory: 500Mi
       image:
         # -- popeye plugin image repository
         repository: ghcr.io/undistro/popeye

--- a/charts/zora/values.yaml
+++ b/charts/zora/values.yaml
@@ -153,6 +153,7 @@ scan:
       # 7. Zora components.
       # See `popeye` configuration file that is used for this case: https://github.com/undistro/zora/blob/main/charts/zora/templates/plugins/popeye-config.yaml
       skipInternalResources: false
+      # -- [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) to add to `popeye` container
       resources:
         requests:
           cpu: 250m

--- a/charts/zora/values.yaml
+++ b/charts/zora/values.yaml
@@ -153,6 +153,10 @@ scan:
       # 7. Zora components.
       # See `popeye` configuration file that is used for this case: https://github.com/undistro/zora/blob/main/charts/zora/templates/plugins/popeye-config.yaml
       skipInternalResources: false
+      resources:
+        limits:
+          cpu: 500m
+          memory: 300Mi
       image:
         # -- popeye plugin image repository
         repository: ghcr.io/undistro/popeye


### PR DESCRIPTION
## Description
Add helm chart param for popeye resources and update default values.

## Linked Issues
Closes https://github.com/undistro/zora/issues/190

## How has this been tested?
- `helm template zora charts/zora/ --set 'scan.plugins.popeye.resources.requests.memory=200Mi'` and see popeye Plugin

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [ ] My changes are covered by tests
