### PR TITLE
Using back popeye image from upstream repository

### DIFF
--- a/charts/zora/README.md
+++ b/charts/zora/README.md
@@ -97,8 +97,8 @@ The following table lists the configurable parameters of the Zora chart and thei
 | scan.plugins.popeye.enabled | bool | `true` |  |
 | scan.plugins.popeye.skipInternalResources | bool | `false` | Specifies whether the following resources should be skipped by `popeye` scans. 1. resources from `kube-system`, `kube-public` and `kube-node-lease` namespaces; 2. kubernetes system reserved RBAC (prefixed with `system:`); 3. `kube-root-ca.crt` configmaps; 4. `default` namespace; 5. `default` serviceaccounts; 6. Helm secrets (prefixed with `sh.helm.release`); 7. Zora components. See `popeye` configuration file that is used for this case: https://github.com/undistro/zora/blob/main/charts/zora/templates/plugins/popeye-config.yaml |
 | scan.plugins.popeye.resources | object | `{"limits":{"cpu":"500m","memory":"500Mi"},"requests":{"cpu":"250m","memory":"256Mi"}}` | [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) to add to `popeye` container |
-| scan.plugins.popeye.image.repository | string | `"ghcr.io/undistro/popeye"` | popeye plugin image repository |
-| scan.plugins.popeye.image.tag | string | `"nonroot"` | popeye plugin image tag |
+| scan.plugins.popeye.image.repository | string | `"docker.io/derailed/popeye"` | popeye plugin image repository |
+| scan.plugins.popeye.image.tag | string | `"v0.11.1"` | popeye plugin image tag |
 | scan.plugins.kubescape.enabled | bool | `false` |  |
 | scan.plugins.kubescape.image.repository | string | `"quay.io/armosec/kubescape"` | kubescape plugin image repository |
 | scan.plugins.kubescape.image.tag | string | `"v2.0.163"` | kubescape plugin image tag |

--- a/charts/zora/values.yaml
+++ b/charts/zora/values.yaml
@@ -163,9 +163,9 @@ scan:
           memory: 500Mi
       image:
         # -- popeye plugin image repository
-        repository: ghcr.io/undistro/popeye
+        repository: docker.io/derailed/popeye
         # -- popeye plugin image tag
-        tag: nonroot
+        tag: v0.11.1
     kubescape:
       enabled: false
       image:

--- a/config/samples/zora_v1alpha1_plugin_popeye.yaml
+++ b/config/samples/zora_v1alpha1_plugin_popeye.yaml
@@ -17,7 +17,7 @@ kind: Plugin
 metadata:
   name: popeye
 spec:
-  image: ghcr.io/undistro/popeye:nonroot
+  image: docker.io/derailed/popeye:v0.11.1
   resources:
     limits:
       cpu: 500m

--- a/hack/patches/popeye_plugin.patch
+++ b/hack/patches/popeye_plugin.patch
@@ -5,6 +5,6 @@
 +  labels:
 +    {{- include "zora.labels" . | nindent 4 }}
  spec:
--  image: ghcr.io/undistro/popeye:nonroot
+-  image: docker.io/derailed/popeye:v0.11.1
 +  image: "{{ .Values.scan.plugins.popeye.image.repository }}:{{ .Values.scan.plugins.popeye.image.tag }}"
    command:

--- a/worker/report/popeye/parse_types.go
+++ b/worker/report/popeye/parse_types.go
@@ -54,7 +54,7 @@ var (
 
 		// General
 		"POP-401": "Unable to locate key reference",
-		"POP-402": "No metric-server detected",
+		"POP-402": "No metrics-server detected",
 		"POP-403": "Deprecated API group",
 		"POP-404": "Deprecation check failed",
 


### PR DESCRIPTION
## Description
Since the issues https://github.com/derailed/popeye/issues/245 and https://github.com/derailed/popeye/pull/241 have been closed, we can use popeye upstream image again.

## Linked Issues
https://github.com/undistro/zora/pull/185

## How has this been tested?
- configuring a cluster scan

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [ ] My changes are covered by tests
