### PR TITLE
Fix duplicate resources of popeye issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,8 +133,9 @@ endif
 .PHONY: install
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/crd | kubectl apply -f -
-	@kubectl apply -f config/samples/zora_v1alpha1_plugin_popeye.yaml
+	@kubectl apply -f config/samples/zora_v1alpha1_plugin_popeye_all.yaml
 	@kubectl apply -f config/samples/zora_v1alpha1_plugin_marvin.yaml
+	@kubectl apply -f config/samples/zora_v1alpha1_customcheck_labels.yaml
 	@kubectl apply -f config/rbac/zora_plugins_role.yaml
 	@kubectl create -f config/rbac/zora_plugins_role_binding.yaml || true
 

--- a/api/zora/v1alpha1/clusterissue_types.go
+++ b/api/zora/v1alpha1/clusterissue_types.go
@@ -50,6 +50,19 @@ type ClusterIssueSpec struct {
 	Custom         bool                 `json:"custom,omitempty"`
 }
 
+// AddResource appends the given resource to the Resources map, if it does not exist
+func (r *ClusterIssueSpec) AddResource(gvr, resource string) {
+	if res, ok := r.Resources[gvr]; ok {
+		for _, re := range res {
+			if re == resource {
+				return
+			}
+		}
+	}
+	r.Resources[gvr] = append(r.Resources[gvr], resource)
+	r.TotalResources++
+}
+
 // ClusterIssueStatus defines the observed state of ClusterIssue
 type ClusterIssueStatus struct {
 }

--- a/config/samples/zora_v1alpha1_plugin_popeye_all.yaml
+++ b/config/samples/zora_v1alpha1_plugin_popeye_all.yaml
@@ -1,0 +1,41 @@
+apiVersion: zora.undistro.io/v1alpha1
+kind: Plugin
+metadata:
+  labels:
+    app.kubernetes.io/name: plugin
+    app.kubernetes.io/instance: popeye
+    app.kubernetes.io/part-of: zora
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: zora
+  name: popeye
+spec:
+  image: ghcr.io/undistro/popeye:pr252
+  resources:
+    limits:
+      cpu: 500m
+      memory: 100Mi
+  command:
+    - /bin/sh
+    - -c
+    - |
+      start=$(date +%s)
+      echo Scanning...
+      POPEYE_REPORT_DIR=$(DONE_DIR) \
+      /bin/popeye \
+        -o json \
+        --kubeconfig $(KUBECONFIG) \
+        --all-namespaces \
+        --force-exit-zero \
+        --save \
+        --output-file results.json
+      exitcode=$(echo $?)
+      if [ $exitcode -ne 0 ]; then
+        echo "ERROR" > $(DONE_DIR)/error
+        cat /tmp/popeye.log
+      else
+        echo $(DONE_DIR)/results.json > $(DONE_DIR)/done
+      fi
+      ls -lh $(DONE_DIR)/
+      end=$(date +%s)
+      echo "Scan has finished in $(($end-$start)) seconds with exit code $exitcode"
+      exit $exitcode

--- a/pkg/worker/report/parse_test.go
+++ b/pkg/worker/report/parse_test.go
@@ -111,7 +111,7 @@ func TestParse(t *testing.T) {
 		},
 
 		{
-			description: "Four Popeye <ClusterIssue> instances with many resources",
+			description: "Five Popeye <ClusterIssue> instances with many resources",
 			testrepname: "popeye/testdata/test_report_2.json",
 			config: &config.Config{
 				DonePath:        "_",
@@ -273,6 +273,43 @@ func TestParse(t *testing.T) {
 						TotalResources: 1,
 						Cluster:        "super_fake_cluster",
 						Url:            "",
+					},
+				},
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ClusterIssue",
+						APIVersion: zorav1a1.SchemeGroupVersion.String(),
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "super_fake_cluster-pop-306-666",
+						Namespace: "super_fake_ns",
+						OwnerReferences: []metav1.OwnerReference{{
+							APIVersion: "batch/v1",
+							Kind:       "Job",
+							Name:       "super_fake_job_id",
+							UID:        types.UID("super_fake_job_uid-666-666"),
+						}},
+						Labels: map[string]string{
+							zorav1a1.LabelScanID:   "super_fake_job_uid-666-666",
+							zorav1a1.LabelCluster:  "super_fake_cluster",
+							zorav1a1.LabelSeverity: "Medium",
+							zorav1a1.LabelIssueID:  "POP-306",
+							zorav1a1.LabelCategory: "Security",
+							zorav1a1.LabelPlugin:   "popeye",
+							zorav1a1.LabelCustom:   "false",
+						},
+					},
+					Spec: zorav1a1.ClusterIssueSpec{
+						ID:       "POP-306",
+						Message:  "Container could be running as root user. Check SecurityContext/Image",
+						Severity: zorav1a1.ClusterIssueSeverity("Medium"),
+						Category: "Security",
+						Resources: map[string][]string{
+							"v1/pods": {"kube-system/cilium-jxncv"},
+						},
+						TotalResources: 1,
+						Cluster:        "super_fake_cluster",
+						Url:            "https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted",
 					},
 				},
 			},

--- a/pkg/worker/report/popeye/parse.go
+++ b/pkg/worker/report/popeye/parse.go
@@ -78,8 +78,7 @@ func Parse(log logr.Logger, popr []byte) ([]*zorav1a1.ClusterIssueSpec, error) {
 					continue
 				}
 				if ci, ok := issuesmap[id]; ok {
-					ci.Resources[san.GVR] = append(ci.Resources[san.GVR], typ)
-					ci.TotalResources++
+					ci.AddResource(san.GVR, typ)
 				} else {
 					spec := &zorav1a1.ClusterIssueSpec{
 						ID:             id,

--- a/pkg/worker/report/popeye/parse_test.go
+++ b/pkg/worker/report/popeye/parse_test.go
@@ -139,7 +139,7 @@ func TestParse(t *testing.T) {
 		},
 
 		{
-			description: "Four <ClusterIssueSpec> instance with many resources",
+			description: "Five <ClusterIssueSpec> instance with many resources",
 			testrepname: "testdata/test_report_2.json",
 			cispecs: []*zorav1a1.ClusterIssueSpec{
 				{
@@ -186,6 +186,17 @@ func TestParse(t *testing.T) {
 					},
 					TotalResources: 1,
 					Url:            "",
+				},
+				{
+					ID:             "POP-306",
+					Message:        "Container could be running as root user. Check SecurityContext/Image",
+					Severity:       "Medium",
+					Category:       "Security",
+					TotalResources: 1,
+					Url:            "https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted",
+					Resources: map[string][]string{
+						"v1/pods": {"kube-system/cilium-jxncv"},
+					},
 				},
 			},
 			toerr: false,

--- a/pkg/worker/report/popeye/testdata/test_report_2.json
+++ b/pkg/worker/report/popeye/testdata/test_report_2.json
@@ -71,6 +71,50 @@
             }
           ]
         }
+      },
+      {
+        "sanitizer": "pods",
+        "gvr": "v1/pods",
+        "issues": {
+          "kube-system/cilium-jxncv": [
+            {
+              "group": "delay-cilium-for-ccm",
+              "gvr": "containers",
+              "level": 2,
+              "message": "[POP-306] Container could be running as root user. Check SecurityContext/Image"
+            },
+            {
+              "group": "mount-cgroup",
+              "gvr": "containers",
+              "level": 2,
+              "message": "[POP-306] Container could be running as root user. Check SecurityContext/Image"
+            },
+            {
+              "group": "apply-sysctl-overwrites",
+              "gvr": "containers",
+              "level": 2,
+              "message": "[POP-306] Container could be running as root user. Check SecurityContext/Image"
+            },
+            {
+              "group": "clean-cilium-state",
+              "gvr": "containers",
+              "level": 2,
+              "message": "[POP-306] Container could be running as root user. Check SecurityContext/Image"
+            },
+            {
+              "group": "install-cni-binaries",
+              "gvr": "containers",
+              "level": 2,
+              "message": "[POP-306] Container could be running as root user. Check SecurityContext/Image"
+            },
+            {
+              "group": "cilium-agent",
+              "gvr": "containers",
+              "level": 2,
+              "message": "[POP-306] Container could be running as root user. Check SecurityContext/Image"
+            }
+          ]
+        }
       }
     ]
   }


### PR DESCRIPTION
## Description
Some popeye sanitizers report issues for each **container**, causing duplicate cluster issues. These changes fix that.

## How has this been tested?
- `make test`
- scanning a resource with more than one "issued" container

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [x] My changes are covered by tests
