### PR TITLE
docs: Added target blank for external links.

### DIFF
--- a/docs/configuration/custom-checks.md
+++ b/docs/configuration/custom-checks.md
@@ -2,8 +2,8 @@
 
 Zora offers a declarative way to create your own checks using the `CustomCheck` API, introduced in version 0.6.
 
-Custom checks use the [Common Expression Language (CEL)](https://github.com/google/cel-spec) 
-to declare the validation rules and are performed by the [Marvin](https://github.com/undistro/marvin) plugin, 
+Custom checks use the [Common Expression Language (CEL)](https://github.com/google/cel-spec){:target="_blank"} 
+to declare the validation rules and are performed by the [Marvin](https://github.com/undistro/marvin){:target="_blank"} plugin, 
 which should be enabled in your cluster scans.
 
 !!! info 
@@ -51,12 +51,12 @@ to be present on `Pods`, `Deployments` and `Services`.
     ```
 
 The `spec.match.resources` defines which resources are checked by the expressions 
-defined in `spec.validations.expression` using [Common Expression Language (CEL)](https://github.com/google/cel-spec).
+defined in `spec.validations.expression` using [Common Expression Language (CEL)](https://github.com/google/cel-spec){:target="_blank"}.
 
 If an expression evaluates to `false`, the check fails, and a `ClusterIssue` is reported.
 
 !!! tip "CEL Playground"
-    To quickly test CEL expressions directly from your browser, check out [CEL Playground](https://playcel.undistro.io/).
+    To quickly test CEL expressions directly from your browser, check out [CEL Playground](https://playcel.undistro.io/){:target="_blank"}.
 
 ### Variables
 
@@ -121,28 +121,28 @@ mycluster-mycheck-4edd75cb85a4   mycluster   mycheck   Required labels   Low    
 ### Examples
 
 All Marvin checks are similar to the `CustomCheck` API. 
-You can see them in the [`internal/builtins`](https://github.com/undistro/marvin/tree/main/internal/builtins) folder for examples.
+You can see them in the [`internal/builtins`](https://github.com/undistro/marvin/tree/main/internal/builtins){:target="_blank"} folder for examples.
 
 Here are some examples of Marvin built-in checks expressions:
 
-- [HostPath volumes must be forbidden](https://github.com/undistro/marvin/blob/main/internal/builtins/pss/baseline/M-104_host_path_volumes.yml)
+- [HostPath volumes must be forbidden](https://github.com/undistro/marvin/blob/main/internal/builtins/pss/baseline/M-104_host_path_volumes.yml){:target="_blank"}
   ```
   !has(podSpec.volumes) || podSpec.volumes.all(vol, !has(vol.hostPath))
   ```
-- [Sharing the host namespaces must be disallowed](https://github.com/undistro/marvin/blob/main/internal/builtins/pss/baseline/M-101_host_namespaces.yml)
+- [Sharing the host namespaces must be disallowed](https://github.com/undistro/marvin/blob/main/internal/builtins/pss/baseline/M-101_host_namespaces.yml){:target="_blank"}
   ```
   (!has(podSpec.hostNetwork) || podSpec.hostNetwork == false) &&
   (!has(podSpec.hostPID) || podSpec.hostPID == false) &&
   (!has(podSpec.hostIPC) || podSpec.hostIPC == false)
   ```
-- [Privileged Pods disable most security mechanisms and must be disallowed](https://github.com/undistro/marvin/blob/main/internal/builtins/pss/baseline/M-102_privileged_containers.yml)
+- [Privileged Pods disable most security mechanisms and must be disallowed](https://github.com/undistro/marvin/blob/main/internal/builtins/pss/baseline/M-102_privileged_containers.yml){:target="_blank"}
   ```
   allContainers.all(container,
     !has(container.securityContext) ||
     !has(container.securityContext.privileged) ||
     container.securityContext.privileged == false)
   ```
-- [HostPorts should be disallowed entirely (recommended) or restricted to a known list](https://github.com/undistro/marvin/blob/main/internal/builtins/pss/baseline/M-105_host_ports.yml)
+- [HostPorts should be disallowed entirely (recommended) or restricted to a known list](https://github.com/undistro/marvin/blob/main/internal/builtins/pss/baseline/M-105_host_ports.yml){:target="_blank"}
   ```
   allContainers.all(container,
     !has(container.ports) ||
@@ -155,9 +155,9 @@ Here are some examples of Marvin built-in checks expressions:
   ```
 
 Marvin's checks and Zora's `CustomCheck` API are inspired in 
-[Kubernetes ValidatingAdmissionPolicy](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy) API, 
+[Kubernetes ValidatingAdmissionPolicy](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy){:target="_blank"} API, 
 introduced in version 1.26 as an alpha feature. 
-Below, the table of [validation expression examples](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/#validation-expression-examples) from Kubernetes documentation.
+Below, the table of [validation expression examples](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/#validation-expression-examples){:target="_blank"} from Kubernetes documentation.
 
 | Expression                                                                                   | Purpose                                                                                        |
 |----------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------|

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -16,14 +16,14 @@ across all your clusters. You can also invite users to your workspace.
 </div>
 
 Currently, it's free for up to 3 clusters.
-Please [contact us](https://undistro.io/contact) if you need unlock more clusters in Zora Dashboard.
+Please [contact us](https://undistro.io/contact){:target="_blank"} if you need unlock more clusters in Zora Dashboard.
 
 ## Getting started
 
 To integrate your cluster with Zora Dashboard, you need to provide the workspace ID
 as an additional parameter in Zora OSS installation command.
 
-1. Sign in at [Zora Dashboard](https://zora-dashboard.undistro.io);
+1. Sign in at [Zora Dashboard](https://zora-dashboard.undistro.io){:target="_blank"};
 2. Click on "Connect cluster" button and copy the workspace ID;
 3. Then provide it in `saas.workspaceID` parameter in [Zora OSS installation command](getting-started/installation.md):
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -7,13 +7,13 @@ title: FAQ
 Do you have any question about Zora?
 We do our best to answer all of your questions on this page. 
 If you can't find your question below, 
-ask it on our [discussion board](https://github.com/undistro/zora/discussions/categories/q-a)!
+ask it on our [discussion board](https://github.com/undistro/zora/discussions/categories/q-a){:target="_blank"}!
 
 ## Is Zora open source?
 
 There are two Zora tools: Zora OSS and Zora Dashboard.
 
-[Zora OSS is open-source](https://github.com/undistro/zora), available under Apache 2.0 license, 
+[Zora OSS is open-source](https://github.com/undistro/zora){:target="_blank"}, available under Apache 2.0 license, 
 and can be used either as standalone tool or integrated with Zora Dashboard.
 
 On the other hand, Zora Dashboard is a SaaS platform that provides a full experience, 
@@ -43,8 +43,8 @@ which is written in Go. A fully declarative approach is not yet supported.
 
 Refer to [plugins page](plugins/index.md) to know more about how plugins work.
 
-Feel free to [open an issue](https://github.com/undistro/zora/issues/new/choose) or 
-[start a discussion](https://github.com/undistro/zora/discussions/categories/q-a) with any suggestions 
+Feel free to [open an issue](https://github.com/undistro/zora/issues/new/choose){:target="_blank"} or 
+[start a discussion](https://github.com/undistro/zora/discussions/categories/q-a){:target="_blank"} with any suggestions 
 regarding this process.
 
 ## Which data is sent to Zora Dashboard (SaaS)?
@@ -61,5 +61,5 @@ where only you and the users you've invited to your workspace will have access.
 Currently, Zora Dashboard is available as a SaaS platform. 
 While we do not offer an on-premise version of Zora Dashboard at this time, we're continuously working to enhance and 
 expand our offerings. If you have specific requirements or are interested in on-premise solutions, 
-please [contact us](https://undistro.io/contact), and we'll be happy to discuss potential options and 
+please [contact us](https://undistro.io/contact){:target="_blank"}, and we'll be happy to discuss potential options and 
 explore how we can meet your needs.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-Zora OSS is installed inside your Kubernetes clusters using [Helm](https://helm.sh/),
+Zora OSS is installed inside your Kubernetes clusters using [Helm](https://helm.sh/){:target="_blank"},
 where the `zora-operator` deployment is created and scans are automatically scheduled for your cluster.
 
 ## Prerequisites
@@ -11,7 +11,7 @@ where the `zora-operator` deployment is created and scans are automatically sche
 
 ## Install with Helm
 
-First, [ensure that your current context of `kubectl` refer to the Kubernetes cluster you wish to install Zora into](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/).
+First, [ensure that your current context of `kubectl` refer to the Kubernetes cluster you wish to install Zora into](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/){:target="_blank"}.
 
 ??? tip "Manage kubectl contexts"
     The following commands can help you to manage kubectl contexts:
@@ -22,7 +22,7 @@ First, [ensure that your current context of `kubectl` refer to the Kubernetes cl
 
     - Use the context for the Kind cluster: `kubectl config use-context kind-kind`
 
-Then, run the following command to install Zora [Helm chart](https://helm.sh/docs/topics/charts/):
+Then, run the following command to install Zora [Helm chart](https://helm.sh/docs/topics/charts/){:target="_blank"}:
 
 === "HTTP chart repository"
     
@@ -108,7 +108,7 @@ You can uninstall Zora and its components by uninstalling the Helm chart install
 helm uninstall zora -n zora-system
 ```
 
-By design, [Helm doesn't upgrade or delete CRDs](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#some-caveats-and-explanations).
+By design, [Helm doesn't upgrade or delete CRDs](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#some-caveats-and-explanations){:target="_blank"}.
 You can permanently delete Zora CRDs and any remaining associated resources from your cluster, using the following command.
 
 ```shell

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ Zora identifies potential issues, misconfigurations, and vulnerabilities.
 
 ## Zora OSS vs Zora Dashboard
 
-[Zora OSS is open-source](https://github.com/undistro/zora), available under Apache 2.0 license,
+[Zora OSS is open-source](https://github.com/undistro/zora){:target="_blank"}, available under Apache 2.0 license,
 and can be used either as standalone tool or integrated with [Zora Dashboard](dashboard.md), 
 a SaaS platform which centralize all your clusters providing a full experience. 
 Please refer to [Zora Dashboard page](dashboard.md) for more details.
@@ -32,25 +32,25 @@ addressing potential issues, misconfigurations, and vulnerabilities.
 
 Zora and its plugins provide actionable insights, guiding you to align your cluster with industry-recognized frameworks 
 such as 
-[NSA-CISA](https://media.defense.gov/2022/Aug/29/2003066362/-1/-1/0/CTR_KUBERNETES_HARDENING_GUIDANCE_1.2_20220829.PDF), 
-[MITRE ATT&CK](https://microsoft.github.io/Threat-Matrix-for-Kubernetes), 
-[CIS Benchmark](https://downloads.cisecurity.org), 
-and [Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards).
+[NSA-CISA](https://media.defense.gov/2022/Aug/29/2003066362/-1/-1/0/CTR_KUBERNETES_HARDENING_GUIDANCE_1.2_20220829.PDF){:target="_blank"}, 
+[MITRE ATT&CK](https://microsoft.github.io/Threat-Matrix-for-Kubernetes){:target="_blank"}, 
+[CIS Benchmark](https://downloads.cisecurity.org){:target="_blank"}, 
+and [Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards){:target="_blank"}.
 
 #### :octicons-sliders-16: Custom checks
 
-Enabled by the [Marvin](https://github.com/undistro/marvin) plugin, Zora offers a declarative way to create your own 
-checks by using [CEL](https://github.com/google/cel-spec) expressions to define validation rules.
+Enabled by the [Marvin](https://github.com/undistro/marvin){:target="_blank"} plugin, Zora offers a declarative way to create your own 
+checks by using [CEL](https://github.com/google/cel-spec){:target="_blank"} expressions to define validation rules.
 
 #### :simple-kubernetes: Kubernetes-native
 
 All scan configurations and plugin reports, including misconfigurations and vulnerabilities,
-are securely stored as [CRDs (Custom Resource Definitions)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
+are securely stored as [CRDs (Custom Resource Definitions)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/){:target="_blank"}
 within your Kubernetes cluster, making it easily accessible through the Kubernetes API and `kubectl` command.
 
 ## Architecture
 
-Zora works as a [Kubernetes Operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/), 
+Zora works as a [Kubernetes Operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/){:target="_blank"}, 
 where both scan and plugin configurations, as well as the results (misconfigurations and vulnerabilities), 
 are managed in CRDs (Custom Resource Definitions).
 
@@ -65,14 +65,14 @@ are managed in CRDs (Custom Resource Definitions).
 
 ## Zora origins
 
-In the early days of the cloud native era, [Borg](https://intl.startrek.com/database_article/borg) 
+In the early days of the cloud native era, [Borg](https://en.wikipedia.org/wiki/Borg){:target="_blank"} 
 dominated the container-oriented cluster management scene.
 The origin of the name Borg refers to the cybernetic life form existing in the Star Trek series,
-that worked as a collective of individuals with a single mind and the same purpose, as well as a "[cluster](https://pt.wikipedia.org/wiki/Cluster)".
+that worked as a collective of individuals with a single mind and the same purpose, as well as a "[cluster](https://pt.wikipedia.org/wiki/Cluster){:target="_blank"}".
 
 As good nerds as we are and wishing to honor our Kubernetes' 
 [predecessor](https://kubernetes.io/blog/2015/04/borg-predecessor-to-kubernetes/) (Borg) we named our project
-[Zora](https://intl.startrek.com/node/15372).
+Zora.
 
 In Star Trek, Zora is the Artificial Intelligence that controls the ship U.S.S Discovery.  
 After being merged with a collective of other intelligences, Zora became sentient and became a member of the team, 

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -87,5 +87,5 @@ then transforms the results and creates `ClusterIssues` and `VulnerabilityReport
 ![Zora plugin diagram](../assets/plugin-arch-dark.png#only-dark)
 
 !!! note
-    This architecture for supporting plugins is inspired by [Sonobuoy](https://sonobuoy.io/), 
+    This architecture for supporting plugins is inspired by [Sonobuoy](https://sonobuoy.io/){:target="_blank"}, 
     a project used for CNCF conformance certification.

--- a/docs/plugins/marvin.md
+++ b/docs/plugins/marvin.md
@@ -13,4 +13,4 @@ Marvin enables Zora's custom checks using CEL. For further information, please v
 
 :simple-docker: **Image**: `ghcr.io/undistro/marvin:v0.2.0`
 
-:simple-github: **GitHub repository**: [https://github.com/undistro/marvin](https://github.com/undistro/marvin)
+:simple-github: **GitHub repository**: [https://github.com/undistro/marvin](https://github.com/undistro/marvin){:target="_blank"}

--- a/docs/plugins/popeye.md
+++ b/docs/plugins/popeye.md
@@ -10,7 +10,7 @@ Popeye is a utility that scans live Kubernetes cluster and reports potential iss
 
 :simple-docker: **Image**: `ghcr.io/undistro/popeye:pr252`
 
-:simple-github: **GitHub repository**: [https://github.com/derailed/popeye](https://github.com/derailed/popeye)
+:simple-github: **GitHub repository**: [https://github.com/derailed/popeye](https://github.com/derailed/popeye){:target="_blank"}
 
 !!! info
     Currently, Zora does not use the official Popeye image (`derailed/popeye`) due to its lack of multi-architecture support.

--- a/docs/plugins/trivy.md
+++ b/docs/plugins/trivy.md
@@ -13,7 +13,7 @@ in different targets like containers, code repositories and **Kubernetes cluster
 
 :simple-docker: **Image**: `ghcr.io/aquasecurity/trivy:0.45.1`
 
-:simple-github: **GitHub repository**: [https://github.com/aquasecurity/trivy](https://github.com/aquasecurity/trivy)
+:simple-github: **GitHub repository**: [https://github.com/aquasecurity/trivy](https://github.com/aquasecurity/trivy){:target="_blank"}
 
 ## Large vulnerability reports
 


### PR DESCRIPTION
## Description
Added target blank to external links  with markdown syntax (`{:target="_blank"}`) for batter navigation on Zora docs. Removed broken links  from Star Trek page.


## How has this been tested?
- Run `mkdocs build`
- Check the external links
