### PR TITLE
UD-1141: Fix instances of stale scan ID information

### DIFF
--- a/internal/controller/zora/clusterscan_controller.go
+++ b/internal/controller/zora/clusterscan_controller.go
@@ -127,6 +127,9 @@ func (r *ClusterScanReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	err := r.reconcile(ctx, clusterscan)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 
 	if r.OnUpdate != nil {
 		if err := r.OnUpdate(ctx, clusterscan); err != nil {

--- a/internal/saas/clusters.go
+++ b/internal/saas/clusters.go
@@ -134,11 +134,14 @@ func NewCluster(cluster v1alpha1.Cluster) Cluster {
 	return cl
 }
 
-func NewScanStatus(scans []v1alpha1.ClusterScan) (map[string]*PluginStatus, *int) {
+func NewScanStatus(clusterScan *v1alpha1.ClusterScan, scans []v1alpha1.ClusterScan) (map[string]*PluginStatus, *int) {
 	var pluginStatus map[string]*PluginStatus
 	var totalIssues *int
 
-	for _, cs := range scans {
+	allScans := []v1alpha1.ClusterScan{}
+	allScans = append(allScans, scans...)
+	allScans = append(allScans, *clusterScan)
+	for _, cs := range allScans {
 		if cs.Status.TotalIssues != nil {
 			if totalIssues == nil {
 				totalIssues = new(int)
@@ -196,8 +199,8 @@ func NewScanStatus(scans []v1alpha1.ClusterScan) (map[string]*PluginStatus, *int
 	return pluginStatus, totalIssues
 }
 
-func NewScanStatusWithIssues(scans []v1alpha1.ClusterScan, issues []v1alpha1.ClusterIssue) map[string]*PluginStatus {
-	pluginStatus, _ := NewScanStatus(scans)
+func NewScanStatusWithIssues(clusterScan *v1alpha1.ClusterScan, scans []v1alpha1.ClusterScan, issues []v1alpha1.ClusterIssue) map[string]*PluginStatus {
+	pluginStatus, _ := NewScanStatus(clusterScan, scans)
 	if pluginStatus == nil {
 		return nil
 	}

--- a/internal/saas/hooks.go
+++ b/internal/saas/hooks.go
@@ -121,7 +121,7 @@ func pushMisconfigs(saasClient Client, c ctrlClient.Client, ctx context.Context,
 		return false, nil
 	}
 
-	status := NewScanStatusWithIssues(scanList.Items, issueList.Items)
+	status := NewScanStatusWithIssues(clusterScan, scanList.Items, issueList.Items)
 	if status == nil {
 		return true, nil
 	}
@@ -190,7 +190,7 @@ func pushVulns(scl Client, cl ctrlClient.Client, ctx context.Context, cs *v1alph
 }
 
 func pushStatusUpdate(saasClient Client, c ctrlClient.Client, ctx context.Context, clusterScan *v1alpha1.ClusterScan, scanList *v1alpha1.ClusterScanList) error {
-	status, _ := NewScanStatus(scanList.Items)
+	status, _ := NewScanStatus(clusterScan, scanList.Items)
 	processedPluginStatus := getPluginProcessedStatus(status)
 
 	if reflect.DeepEqual(processedPluginStatus, clusterScan.Status.ProcessedPluginStatus) {


### PR DESCRIPTION
## Description
This PR deals with two issues which can cause stale information to be stored
- The main ClusterScan controller continues with processing when reconciliation has already errored, preventing the LastSuccessfulScanID information from being updated
- The generated ScanStatus is derived from the live data and ignores changes made to the currently reconciling ClusterScan, which is persisted at the end of the reconciler.

## Linked Issues

## How has this been tested?
- The easiest way to reproduce this issue appears to be running with a ClusterScan set to only persist the last successful scan, i.e. setting the `successfulScansHistoryLimit` to 1.
- Let the scanning run for a few iterations, after each run check the database to see if there are zero (0) vulnerabilities

## Checklist
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [ ] I have documented my code (if applicable)
- [ ] My changes are covered by tests
