### PR TITLE
UD-1190: Add support for plugin pod annotations and plugin service ac…

### DIFF
--- a/api/zora/v1alpha1/plugin_types.go
+++ b/api/zora/v1alpha1/plugin_types.go
@@ -63,6 +63,10 @@ type PluginSpec struct {
 	// Cannot be updated.
 	Env []corev1.EnvVar `json:"env,omitempty"`
 
+	// Annotations to set in plugin and worker containers.
+	// Cannot be updated.
+	Annotations map[string]string `json:"annotations,omitempty"`
+
 	// Compute Resources required by this container.
 	// Cannot be updated.
 	// More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/

--- a/api/zora/v1alpha1/zz_generated.deepcopy.go
+++ b/api/zora/v1alpha1/zz_generated.deepcopy.go
@@ -776,6 +776,13 @@ func (in *PluginSpec) DeepCopyInto(out *PluginSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	in.Resources.DeepCopyInto(&out.Resources)
 	if in.SecurityContext != nil {
 		in, out := &in.SecurityContext, &out.SecurityContext

--- a/charts/zora/README.md
+++ b/charts/zora/README.md
@@ -103,16 +103,20 @@ The following table lists the configurable parameters of the Zora chart and thei
 | scan.vulnerability.plugins | list | `["trivy"]` | Vulnerability scanners plugins |
 | scan.worker.image.repository | string | `"ghcr.io/undistro/zora/worker"` | worker image repository |
 | scan.worker.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
+| scan.plugins.annotations | object | `{}` | Annotations added to the plugin service account |
 | scan.plugins.marvin.resources | object | `{"limits":{"cpu":"500m","memory":"500Mi"},"requests":{"cpu":"250m","memory":"256Mi"}}` | [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) to add to `marvin` container |
+| scan.plugins.marvin.podAnnotations | object | `{}` | Annotations added to the marvin pods |
 | scan.plugins.marvin.image.repository | string | `"ghcr.io/undistro/marvin"` | marvin plugin image repository |
 | scan.plugins.marvin.image.tag | string | `"v0.2.1"` | marvin plugin image tag |
 | scan.plugins.trivy.ignoreUnfixed | bool | `false` | Specifies whether only fixed vulnerabilities should be reported |
 | scan.plugins.trivy.ignoreDescriptions | bool | `false` | Specifies whether vulnerability descriptions should be ignored |
 | scan.plugins.trivy.resources | object | `{}` | [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) to add to `trivy` container |
+| scan.plugins.trivy.podAnnotations | object | `{}` | Annotations added to the trivy pods |
 | scan.plugins.trivy.image.repository | string | `"ghcr.io/aquasecurity/trivy"` | trivy plugin image repository |
 | scan.plugins.trivy.image.tag | string | `"0.48.2"` | trivy plugin image tag |
 | scan.plugins.popeye.skipInternalResources | bool | `false` | Specifies whether the following resources should be skipped by `popeye` scans. 1. resources from `kube-system`, `kube-public` and `kube-node-lease` namespaces; 2. kubernetes system reserved RBAC (prefixed with `system:`); 3. `kube-root-ca.crt` configmaps; 4. `default` namespace; 5. `default` serviceaccounts; 6. Helm secrets (prefixed with `sh.helm.release`); 7. Zora components. See `popeye` configuration file that is used for this case: https://github.com/undistro/zora/blob/main/charts/zora/templates/plugins/popeye-config.yaml |
 | scan.plugins.popeye.resources | object | `{"limits":{"cpu":"500m","memory":"500Mi"},"requests":{"cpu":"250m","memory":"256Mi"}}` | [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) to add to `popeye` container |
+| scan.plugins.popeye.podAnnotations | object | `{}` | Annotations added to the popeye pods |
 | scan.plugins.popeye.image.repository | string | `"ghcr.io/undistro/popeye"` | popeye plugin image repository |
 | scan.plugins.popeye.image.tag | string | `"pr252"` | popeye plugin image tag |
 | kubexnsImage.repository | string | `"ghcr.io/undistro/kubexns"` | kubexns image repository |

--- a/charts/zora/crds/zora.undistro.io_plugins.yaml
+++ b/charts/zora/crds/zora.undistro.io_plugins.yaml
@@ -58,6 +58,12 @@ spec:
           spec:
             description: PluginSpec defines the desired state of Plugin
             properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: Annotations to set in plugin and worker containers. Cannot
+                  be updated.
+                type: object
               args:
                 description: 'Arguments to the entrypoint. The docker image''s CMD
                   is used if this is not provided. Variable references $(VAR_NAME)

--- a/charts/zora/templates/operator/deployment.yaml
+++ b/charts/zora/templates/operator/deployment.yaml
@@ -74,6 +74,9 @@ spec:
             - --worker-image={{ printf "%s:%s" .Values.scan.worker.image.repository (.Values.scan.worker.image.tag | default .Chart.AppVersion) }}
             - --cronjob-clusterrolebinding-name=zora-plugins-rolebinding
             - --cronjob-serviceaccount-name=zora-plugins
+{{- if .Values.scan.plugins.annotations}}
+            - --cronjob-serviceaccount-annotations={{ $first := true }}{{- range $key, $value := .Values.scan.plugins.annotations }}{{if not $first}},{{else}}{{$first = false}}{{end}}{{ $key }}={{$value}}{{- end }}
+{{- end }}
             - --saas-workspace-id={{ .Values.saas.workspaceID }}
             - --saas-server={{ .Values.saas.server }}
             - --version={{ .Chart.Version }}

--- a/charts/zora/templates/plugins/marvin.yaml
+++ b/charts/zora/templates/plugins/marvin.yaml
@@ -30,6 +30,10 @@ spec:
     runAsNonRoot: true
     readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
+  {{- if .Values.scan.plugins.marvin.podAnnotations }}
+  annotations:
+    {{- toYaml .Values.scan.plugins.marvin.podAnnotations | nindent 4 }}
+  {{- end }}
   command:
     - /bin/sh
     - -c

--- a/charts/zora/templates/plugins/popeye.yaml
+++ b/charts/zora/templates/plugins/popeye.yaml
@@ -34,6 +34,10 @@ spec:
   securityContext:
     runAsNonRoot: true
     allowPrivilegeEscalation: false
+  {{- if .Values.scan.plugins.popeye.podAnnotations }}
+  annotations:
+    {{- toYaml .Values.scan.plugins.popeye.podAnnotations | nindent 4 }}
+  {{- end }}
   command:
     - /bin/sh
     - -c

--- a/charts/zora/templates/plugins/trivy.yaml
+++ b/charts/zora/templates/plugins/trivy.yaml
@@ -31,6 +31,10 @@ spec:
   env:
     - name: TRIVY_IGNORE_VULN_DESCRIPTIONS
       value: {{ .Values.scan.plugins.trivy.ignoreDescriptions | quote }}
+  {{- if .Values.scan.plugins.trivy.podAnnotations }}
+  annotations:
+    {{- toYaml .Values.scan.plugins.trivy.podAnnotations | nindent 4 }}
+  {{- end }}
   command:
     - /bin/sh
     - -c

--- a/charts/zora/values.yaml
+++ b/charts/zora/values.yaml
@@ -175,6 +175,8 @@ scan:
       # -- Overrides the image tag whose default is the chart appVersion
       tag: ""
   plugins:
+    # -- Annotations added to the plugin service account
+    annotations: {}
     marvin:
       # -- [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) to add to `marvin` container
       resources:
@@ -184,6 +186,8 @@ scan:
         limits:
           cpu: 500m
           memory: 500Mi
+      # -- Annotations added to the marvin pods
+      podAnnotations: {}
       image:
         # -- marvin plugin image repository
         repository: ghcr.io/undistro/marvin
@@ -197,6 +201,8 @@ scan:
       ignoreDescriptions: false
       # -- [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) to add to `trivy` container
       resources: {}
+      # -- Annotations added to the trivy pods
+      podAnnotations: {}
       image:
         # -- trivy plugin image repository
         repository: ghcr.io/aquasecurity/trivy
@@ -221,6 +227,8 @@ scan:
         limits:
           cpu: 500m
           memory: 500Mi
+      # -- Annotations added to the popeye pods
+      podAnnotations: {}
       image:
         # -- popeye plugin image repository
         repository: ghcr.io/undistro/popeye

--- a/config/crd/bases/zora.undistro.io_plugins.yaml
+++ b/config/crd/bases/zora.undistro.io_plugins.yaml
@@ -44,6 +44,12 @@ spec:
           spec:
             description: PluginSpec defines the desired state of Plugin
             properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                description: Annotations to set in plugin and worker containers. Cannot
+                  be updated.
+                type: object
               args:
                 description: 'Arguments to the entrypoint. The docker image''s CMD
                   is used if this is not provided. Variable references $(VAR_NAME)

--- a/docs/configuration/aws-elastic-container-registry.md
+++ b/docs/configuration/aws-elastic-container-registry.md
@@ -1,0 +1,12 @@
+# AWS Elastic Container Registry
+
+If you are running within AWS, and making use of a private [Elastic Container Registry (ECR)](https://aws.amazon.com/ecr/) to host your application images, then the Trivy plugin will be unable to scan those images unless access is granted to the registry through an [Identity and Access Managemnent (IAM)](https://aws.amazon.com/iam/) role assigned to the service account running the Trivy plugins.
+
+Once an IAM role granting grant access to the ECR has been created, this can be assigned to the service account by including the following additional parameter when running the `helm upgrade --install` command.
+
+```shell
+--set scan.plugins.annotations.eks\\.amazonaws\\.com/role-arn=arn:aws:iam::<AWS_ACCOUNT_ID>:role/<ROLE_NAME>
+```
+where `<AWS_ACCOUNT_ID>` should be replaced witth your AWS account ID, and `<ROLE_NAME>` should be replaced with the name of the role granting access to the ECR.
+
+This will now allow the Trivy plugin to scan your internal images for vulnerabilities.

--- a/internal/controller/zora/clusterscan_controller.go
+++ b/internal/controller/zora/clusterscan_controller.go
@@ -63,6 +63,7 @@ type ClusterScanReconciler struct {
 	ServiceAccountName      string
 	KubexnsImage            string
 	ChecksConfigMap         string
+	Annotations             map[string]string
 	OnUpdate                saas.ClusterScanHook
 	OnDelete                saas.ClusterScanHook
 }
@@ -462,7 +463,7 @@ func (r *ClusterScanReconciler) applyRBAC(ctx context.Context, clusterscan *v1al
 		return err
 	}
 
-	sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: r.ServiceAccountName, Namespace: clusterscan.Namespace}}
+	sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: r.ServiceAccountName, Namespace: clusterscan.Namespace, Annotations: r.Annotations}}
 	res, err := ctrl.CreateOrUpdate(ctx, r.Client, sa, func() error {
 		return controllerutil.SetOwnerReference(clusterscan, sa, r.Scheme)
 	})

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,7 @@ nav:
           - Suspending scans: configuration/suspend-scan.md
           - Retain issues: configuration/retain-issues.md
           - Ignore unfixed vulnerabilities: plugins/trivy/#large-vulnerability-reports
+          - Scanning Images hosted in AWS Elastic Container Registry: configuration/aws-elastic-container-registry.md
       - "🔌 Plugins":
           - Overview: plugins/index.md
           - Misconfiguration:

--- a/pkg/plugins/cronjob.go
+++ b/pkg/plugins/cronjob.go
@@ -115,7 +115,7 @@ func (r *CronJobMutator) Mutate() error {
 	r.Existing.Spec.JobTemplate.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyNever
 	r.Existing.Spec.JobTemplate.Spec.BackoffLimit = pointer.Int32(0)
 	r.Existing.Spec.JobTemplate.Spec.Template.Spec.ServiceAccountName = r.ServiceAccountName
-	r.Existing.Spec.JobTemplate.Spec.Template.Annotations = map[string]string{annotationDefaultContainer: r.Plugin.Name}
+	r.Existing.Spec.JobTemplate.Spec.Template.Annotations = r.annotations()
 	r.Existing.Spec.JobTemplate.Spec.Template.Spec.Volumes = []corev1.Volume{
 		{
 			Name:         resultsVolumeName,
@@ -319,4 +319,14 @@ func (r *CronJobMutator) workerEnv() []corev1.EnvVar {
 		},
 	)
 	return p
+}
+
+func (r *CronJobMutator) annotations() map[string]string {
+	annotations := map[string]string{}
+	for key, value := range r.Plugin.Spec.Annotations {
+		annotations[key] = value
+	}
+	annotations[annotationDefaultContainer] = r.Plugin.Name
+
+	return annotations
 }


### PR DESCRIPTION
…count annotations

## Description
This PR enables annotations to be provided for each plugin pod and for the plugin service account.

One use of this would be to enable access to specific IAM roles when running in EKS, for example for Trivy to access a private ECR.

## Linked Issues

## How has this been tested?
- Creation of a private ECR, an EKS cluster and a deployment of an image from the private repo
- Helm installation of zora using the following options
  - `--set scan.plugins.annotations.eks\\.amazonaws\\.com/role-arn=arn:aws:iam::127647282379:role/undistro-test-ecr-role` (annotation on the ServiceAccount, must use the role created for accessing the ECR)
  - `--set scan.plugins.marvin.podAnnotations.marvin-annotation="marvin-value"` (marvin cronjob/pod annotation)
  - `--set scan.plugins.trivy.podAnnotations.trivy-annotation="trivy-value"`
- check service account for annotation
- check cronjobs and executed pods for annotations
- check dashboard for vulnerabilities from private repo images
- check trivy pod to ensure there are no errors for the images from a private repo

## Checklist
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [ ] I have documented my code (if applicable)
- [ ] My changes are covered by tests
