### PR TITLE
bump popeye version to 0.11.3

### DIFF
--- a/charts/zora/README.md
+++ b/charts/zora/README.md
@@ -114,7 +114,7 @@ The following table lists the configurable parameters of the Zora chart and thei
 | scan.plugins.popeye.skipInternalResources | bool | `false` | Specifies whether the following resources should be skipped by `popeye` scans. 1. resources from `kube-system`, `kube-public` and `kube-node-lease` namespaces; 2. kubernetes system reserved RBAC (prefixed with `system:`); 3. `kube-root-ca.crt` configmaps; 4. `default` namespace; 5. `default` serviceaccounts; 6. Helm secrets (prefixed with `sh.helm.release`); 7. Zora components. See `popeye` configuration file that is used for this case: https://github.com/undistro/zora/blob/main/charts/zora/templates/plugins/popeye-config.yaml |
 | scan.plugins.popeye.resources | object | `{"limits":{"cpu":"500m","memory":"500Mi"},"requests":{"cpu":"250m","memory":"256Mi"}}` | [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) to add to `popeye` container |
 | scan.plugins.popeye.image.repository | string | `"ghcr.io/undistro/popeye"` | popeye plugin image repository |
-| scan.plugins.popeye.image.tag | string | `"pr252"` | popeye plugin image tag |
+| scan.plugins.popeye.image.tag | string | `"v0.11.3"` | popeye plugin image tag |
 | kubexnsImage.repository | string | `"ghcr.io/undistro/kubexns"` | kubexns image repository |
 | kubexnsImage.tag | string | `"v0.1.2"` | kubexns image tag |
 | customChecksConfigMap | string | `"zora-custom-checks"` | Custom checks ConfigMap name |

--- a/charts/zora/values.yaml
+++ b/charts/zora/values.yaml
@@ -225,7 +225,7 @@ scan:
         # -- popeye plugin image repository
         repository: ghcr.io/undistro/popeye
         # -- popeye plugin image tag
-        tag: pr252
+        tag: v0.11.3
 
 kubexnsImage:
   # -- kubexns image repository

--- a/config/samples/zora_v1alpha1_plugin_popeye.yaml
+++ b/config/samples/zora_v1alpha1_plugin_popeye.yaml
@@ -10,7 +10,7 @@ metadata:
   name: popeye
 spec:
   type: misconfiguration
-  image: ghcr.io/undistro/popeye:pr252
+  image: ghcr.io/undistro/popeye:v0.11.3
   resources:
     limits:
       cpu: 500m

--- a/config/samples/zora_v1alpha1_plugin_popeye_all.yaml
+++ b/config/samples/zora_v1alpha1_plugin_popeye_all.yaml
@@ -10,7 +10,7 @@ metadata:
   name: popeye
 spec:
   type: misconfiguration
-  image: ghcr.io/undistro/popeye:pr252
+  image: ghcr.io/undistro/popeye:v0.11.3
   resources:
     limits:
       cpu: 500m

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -16,7 +16,7 @@ kubectl get plugins -n zora-system
 ```
 NAME     IMAGE                               TYPE               AGE
 marvin   ghcr.io/undistro/marvin:v0.2.1      misconfiguration   14m
-popeye   ghcr.io/undistro/popeye:pr252       misconfiguration   14m
+popeye   ghcr.io/undistro/popeye:v0.11.3     misconfiguration   14m
 trivy    ghcr.io/aquasecurity/trivy:0.48.2   vulnerability      14m
 ```
 

--- a/docs/plugins/popeye.md
+++ b/docs/plugins/popeye.md
@@ -8,7 +8,7 @@ Popeye is a utility that scans live Kubernetes cluster and reports potential iss
 
 :octicons-codescan-24: **Type**: `misconfiguration`
 
-:simple-docker: **Image**: `ghcr.io/undistro/popeye:pr252`
+:simple-docker: **Image**: `ghcr.io/undistro/popeye:v0.11.3`
 
 :simple-github: **GitHub repository**: [https://github.com/derailed/popeye](https://github.com/derailed/popeye){:target="_blank"}
 


### PR DESCRIPTION
## Description
Bump popeye version to 0.11.3

```
trivy image ghcr.io/undistro/popeye:v0.11.3 

2024-02-09T11:16:34.624-0300    INFO    Vulnerability scanning is enabled
2024-02-09T11:16:34.624-0300    INFO    Secret scanning is enabled
2024-02-09T11:16:34.624-0300    INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-02-09T11:16:34.624-0300    INFO    Please see also https://aquasecurity.github.io/trivy/v0.48/docs/scanner/secret/#recommendation for faster secret detection
2024-02-09T11:16:36.410-0300    INFO    Detected OS: alpine
2024-02-09T11:16:36.410-0300    WARN    This OS version is not on the EOL list: alpine 3.19
2024-02-09T11:16:36.410-0300    INFO    Detecting Alpine vulnerabilities...
2024-02-09T11:16:36.413-0300    INFO    Number of language-specific files: 1
2024-02-09T11:16:36.414-0300    INFO    Detecting gobinary vulnerabilities...

ghcr.io/undistro/popeye:v0.11.3 (alpine 3.19.1)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```

## How has this been tested?
- Installing Zora and waiting for a scan

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [ ] My changes are covered by tests
