### PR TITLE
UD-1199: Update helm templates and cronjob creation to enforce correc…

### DIFF
--- a/charts/zora/templates/_helpers.tpl
+++ b/charts/zora/templates/_helpers.tpl
@@ -84,7 +84,7 @@ Create the name of the service account to use in Operator
 {{- end }}
 
 {{- define "zora.clusterName" }}
-{{- regexReplaceAll "\\W+" (required "`clusterName` is required." .Values.clusterName) "-" }}
+{{- include "truncate.name" (dict "name" (regexReplaceAll "\\W+" (required "`clusterName` is required." .Values.clusterName) "-") "len" 63 ) }}
 {{- end }}
 
 {{- define "zora.hourlySchedule" }}
@@ -112,4 +112,21 @@ Create the name of the service account to use in Operator
 
 {{- define "zora.vulnSchedule" }}
 {{- default (include "zora.dailySchedule" .) .Values.scan.vulnerability.schedule }}
+{{- end }}
+
+{{/*
+Truncate a name to a specific length
+@param .name the name of the component
+@param .len the maximum length to return
+*/}}
+{{- define "truncate.name" }}
+{{- if gt (len .name) .len }}
+{{- $maxLen := int (sub .len 3) }}
+{{- $suffixLen := int (div $maxLen 2) }}
+{{- $prefixLen := int (sub $maxLen $suffixLen) }}
+{{- $suffixStart := int (sub (len .name) $suffixLen) }}
+{{- printf "%s---%s" (substr 0 $prefixLen .name) (substr $suffixStart (len .name) .name) }}
+{{- else }}
+{{- .name }}
+{{- end }}
 {{- end }}

--- a/charts/zora/templates/clusterscan/clusterscan.yaml
+++ b/charts/zora/templates/clusterscan/clusterscan.yaml
@@ -30,7 +30,8 @@ metadata:
   labels:
     zora.undistro.io/default: "true"
     {{- include "zora.labels" . | nindent 4 }}
-  name: {{ include "zora.clusterName" . }}-misconfig
+  name: {{ include "truncate.name" (dict "name" (printf "%s-misconfig" (include "zora.clusterName" .)) "len" 63 ) }}
+
 spec:
   clusterRef:
     name: {{ include "zora.clusterName" . }}
@@ -51,7 +52,7 @@ metadata:
   labels:
     zora.undistro.io/default: "true"
     {{- include "zora.labels" . | nindent 4 }}
-  name: {{ include "zora.clusterName" . }}-vuln
+  name: {{ include "truncate.name" (dict "name" (printf "%s-vuln" (include "zora.clusterName" .)) "len" 63 ) }}
 spec:
   clusterRef:
     name: {{ include "zora.clusterName" . }}

--- a/internal/controller/zora/utils.go
+++ b/internal/controller/zora/utils.go
@@ -1,0 +1,29 @@
+// Copyright 2024 Undistro Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zora
+
+import "fmt"
+
+func truncateName(name string, length int) string {
+	nameLen := len(name)
+	if nameLen <= length {
+		return name
+	} else {
+		maxLength := length - 3
+		suffixLen := maxLength / 2
+		prefixLen := maxLength - suffixLen
+		return fmt.Sprintf("%s---%s", name[0:prefixLen], name[nameLen-suffixLen:])
+	}
+}


### PR DESCRIPTION
…t limits

## Description
This PR enforces the correct limits for the cluster scan names and the reconciled cronjob names

## Linked Issues

## How has this been tested?
- Create cluster with long name, for example
  - `arn-aws-eks-us-east-1-127647282379-cluster-undistro--longest-test` (65 characters)
- run `kubectl get cluster -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'` and check the name is truncated
- run `kubectl get scan -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'` and check the names are truncated
- run `kubectl get cronjob -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'` and check the cronjobs exist and are truncated

## Checklist
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [ ] I have documented my code (if applicable)
- [ ] My changes are covered by tests
