### PR TITLE
Expose plugins `env` and `envFrom` as helm chart parameters

### DIFF
--- a/charts/zora/README.md
+++ b/charts/zora/README.md
@@ -108,17 +108,23 @@ The following table lists the configurable parameters of the Zora chart and thei
 | scan.plugins.marvin.podAnnotations | object | `{}` | Annotations added to the marvin pods |
 | scan.plugins.marvin.image.repository | string | `"ghcr.io/undistro/marvin"` | marvin plugin image repository |
 | scan.plugins.marvin.image.tag | string | `"v0.2.1"` | marvin plugin image tag |
+| scan.plugins.marvin.env | list | `[]` | List of environment variables to set in marvin container. |
+| scan.plugins.marvin.envFrom | list | `[]` | List of sources to populate environment variables in marvin container. |
 | scan.plugins.trivy.ignoreUnfixed | bool | `false` | Specifies whether only fixed vulnerabilities should be reported |
 | scan.plugins.trivy.ignoreDescriptions | bool | `false` | Specifies whether vulnerability descriptions should be ignored |
 | scan.plugins.trivy.resources | object | `{}` | [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) to add to `trivy` container |
 | scan.plugins.trivy.podAnnotations | object | `{}` | Annotations added to the trivy pods |
 | scan.plugins.trivy.image.repository | string | `"ghcr.io/aquasecurity/trivy"` | trivy plugin image repository |
 | scan.plugins.trivy.image.tag | string | `"0.48.2"` | trivy plugin image tag |
+| scan.plugins.trivy.env | list | `[]` | List of environment variables to set in trivy container. |
+| scan.plugins.trivy.envFrom | list | `[]` | List of sources to populate environment variables in trivy container. |
 | scan.plugins.popeye.skipInternalResources | bool | `false` | Specifies whether the following resources should be skipped by `popeye` scans. 1. resources from `kube-system`, `kube-public` and `kube-node-lease` namespaces; 2. kubernetes system reserved RBAC (prefixed with `system:`); 3. `kube-root-ca.crt` configmaps; 4. `default` namespace; 5. `default` serviceaccounts; 6. Helm secrets (prefixed with `sh.helm.release`); 7. Zora components. See `popeye` configuration file that is used for this case: https://github.com/undistro/zora/blob/main/charts/zora/templates/plugins/popeye-config.yaml |
 | scan.plugins.popeye.resources | object | `{"limits":{"cpu":"500m","memory":"500Mi"},"requests":{"cpu":"250m","memory":"256Mi"}}` | [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) to add to `popeye` container |
 | scan.plugins.popeye.podAnnotations | object | `{}` | Annotations added to the popeye pods |
 | scan.plugins.popeye.image.repository | string | `"ghcr.io/undistro/popeye"` | popeye plugin image repository |
 | scan.plugins.popeye.image.tag | string | `"v0.11.3"` | popeye plugin image tag |
+| scan.plugins.popeye.env | list | `[]` | List of environment variables to set in popeye container. |
+| scan.plugins.popeye.envFrom | list | `[]` | List of sources to populate environment variables in popeye container. |
 | kubexnsImage.repository | string | `"ghcr.io/undistro/kubexns"` | kubexns image repository |
 | kubexnsImage.tag | string | `"v0.1.2"` | kubexns image tag |
 | customChecksConfigMap | string | `"zora-custom-checks"` | Custom checks ConfigMap name |

--- a/charts/zora/templates/plugins/marvin.yaml
+++ b/charts/zora/templates/plugins/marvin.yaml
@@ -30,6 +30,14 @@ spec:
     runAsNonRoot: true
     readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
+  {{- with .Values.scan.plugins.marvin.envFrom }}
+  envFrom:
+    {{- toYaml . | nindent 4}}
+  {{- end }}
+  {{- with .Values.scan.plugins.marvin.env }}
+  env:
+    {{- toYaml . | nindent 4}}
+  {{- end }}
   {{- if .Values.scan.plugins.marvin.podAnnotations }}
   annotations:
     {{- toYaml .Values.scan.plugins.marvin.podAnnotations | nindent 4 }}

--- a/charts/zora/templates/plugins/popeye.yaml
+++ b/charts/zora/templates/plugins/popeye.yaml
@@ -25,12 +25,21 @@ spec:
   resources:
     {{- toYaml .Values.scan.plugins.popeye.resources | nindent 4 }}
   {{- end }}
-{{- if .Values.scan.plugins.popeye.skipInternalResources }}
+  {{- if or .Values.scan.plugins.popeye.skipInternalResources .Values.scan.plugins.popeye.envFrom }}
   envFrom:
+  {{- end }}
+  {{- if or .Values.scan.plugins.popeye.skipInternalResources }}
     - configMapRef:
         name: popeye-config
         optional: true
-{{- end }}
+  {{- end }}
+    {{- with .Values.scan.plugins.popeye.envFrom }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.scan.plugins.popeye.env }}
+  env:
+    {{- toYaml . | nindent 4}}
+  {{- end }}
   securityContext:
     runAsNonRoot: true
     allowPrivilegeEscalation: false

--- a/charts/zora/templates/plugins/trivy.yaml
+++ b/charts/zora/templates/plugins/trivy.yaml
@@ -28,9 +28,16 @@ spec:
   mountCustomChecksVolume: false
   securityContext:
     allowPrivilegeEscalation: false
+  {{- with .Values.scan.plugins.trivy.envFrom }}
+  envFrom:
+    {{- toYaml . | nindent 4}}
+  {{- end }}
   env:
     - name: TRIVY_IGNORE_VULN_DESCRIPTIONS
       value: {{ .Values.scan.plugins.trivy.ignoreDescriptions | quote }}
+    {{- with .Values.scan.plugins.trivy.env }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     {{- if .Values.httpsProxy }}
     - name: HTTPS_PROXY
       value: {{ .Values.httpsProxy | quote }}

--- a/charts/zora/values.yaml
+++ b/charts/zora/values.yaml
@@ -208,6 +208,20 @@ scan:
         repository: ghcr.io/aquasecurity/trivy
         # -- trivy plugin image tag
         tag: 0.48.2
+      # -- List of environment variables to set in trivy container.
+      env: []
+      #  - name: AWS_REGION
+      #    value: us-east-1
+      #  - name: TRIVY_PASSWORD
+      #    valueFrom:
+      #      secretKeyRef:
+      #        key: TRIVY_PASSWORD
+      #        name: trivy-password
+
+      # -- List of sources to populate environment variables in trivy container.
+      envFrom: []
+      #  - secretRef:
+      #      name: trivy-credentials
     popeye:
       # -- Specifies whether the following resources should be skipped by `popeye` scans.
       # 1. resources from `kube-system`, `kube-public` and `kube-node-lease` namespaces;

--- a/charts/zora/values.yaml
+++ b/charts/zora/values.yaml
@@ -193,6 +193,10 @@ scan:
         repository: ghcr.io/undistro/marvin
         # -- marvin plugin image tag
         tag: v0.2.1
+      # -- List of environment variables to set in marvin container.
+      env: []
+      # -- List of sources to populate environment variables in marvin container.
+      envFrom: []
 
     trivy:
       # -- Specifies whether only fixed vulnerabilities should be reported

--- a/charts/zora/values.yaml
+++ b/charts/zora/values.yaml
@@ -252,6 +252,10 @@ scan:
         repository: ghcr.io/undistro/popeye
         # -- popeye plugin image tag
         tag: v0.11.3
+      # -- List of environment variables to set in popeye container.
+      env: []
+      # -- List of sources to populate environment variables in popeye container.
+      envFrom: []
 
 kubexnsImage:
   # -- kubexns image repository


### PR DESCRIPTION
## Description
Expose plugins `env` and `envFrom` as helm chart parameters.

It may be necessary to set environment variables like `AWS_REGION` in trivy container.

## How has this been tested?
By running `helm template zora charts/zora/ --set clusterName=mycluster` with and without `scan.plugins.trivy.env` parameter set.

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [ ] My changes are covered by tests
