### PR TITLE
Add documentation page for scanning ACR images

### DIFF
--- a/docs/configuration/acr.md
+++ b/docs/configuration/acr.md
@@ -1,0 +1,55 @@
+# Azure Container Registry (ACR)
+
+If you are running within Azure, and making use of a private [Azure Container Registry (ACR)](https://learn.microsoft.com/en-us/azure/container-registry/)
+to host your application images, then the Trivy plugin will be unable to scan those images unless access is granted to 
+the registry through a service principal with `AcrPull` role assigned.
+
+## Creating service principal
+
+The following [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/) command creates a service principal 
+with `AcrPull` role assigned, and stores the output including the credentials into `SP_DATA` environment variable.
+
+!!! note
+    Please replace `<SUBSCRIPTION_ID>`, `<RESOURCE_GROUP>`, and `<REGISTRY_NAME>` before running the command below.
+
+```shell
+export SP_DATA=$(az ad sp create-for-rbac --name ZoraTrivy --role AcrPull --scope "/subscriptions/<SUBSCRIPTION_ID>/resourceGroups/<RESOURCE_GROUP>/providers/Microsoft.ContainerRegistry/registries/<REGISTRY_NAME>")
+```
+
+## Usage
+
+Once the service principal is created and the credentials are in `SP_DATA` environment variable,
+create a Kubernetes secret to store these credentials by running:
+
+```shell
+kubectl create secret generic trivy-acr-credentials -n zora-system \
+  --from-literal=AZURE_CLIENT_ID=$(echo $SP_DATA | jq -r '.appId') \
+  --from-literal=AZURE_CLIENT_SECRET=$(echo $SP_DATA | jq -r '.password') \
+  --from-literal=AZURE_TENANT_ID=$(echo $SP_DATA | jq -r '.tenant')
+```
+
+!!! note
+    If you are running this command before a Zora installation, you may need to create the `zora-system` namespace.
+    ```shell
+    kubectl create namespace zora-system
+    ```
+
+Now set the secret name in a `values.yaml`
+
+```yaml hl_lines="6"
+scan:
+  plugins:
+    trivy:
+      envFrom:
+        - secretRef:
+            name: trivy-acr-credentials
+            optional: true
+```
+
+Then provide it in `helm upgrade --install` command
+
+```shell
+-f values.yaml
+```
+
+This will now allow the Trivy plugin to scan your internal images for vulnerabilities.

--- a/docs/configuration/aws-elastic-container-registry.md
+++ b/docs/configuration/aws-elastic-container-registry.md
@@ -2,11 +2,11 @@
 
 If you are running within AWS, and making use of a private [Elastic Container Registry (ECR)](https://aws.amazon.com/ecr/) to host your application images, then the Trivy plugin will be unable to scan those images unless access is granted to the registry through an [Identity and Access Managemnent (IAM)](https://aws.amazon.com/iam/) role assigned to the service account running the Trivy plugins.
 
-Once an IAM role granting grant access to the ECR has been created, this can be assigned to the service account by including the following additional parameter when running the `helm upgrade --install` command.
+Once an IAM role granting access to the ECR has been created, this can be assigned to the service account by including the following additional parameter when running the `helm upgrade --install` command.
 
 ```shell
 --set scan.plugins.annotations.eks\\.amazonaws\\.com/role-arn=arn:aws:iam::<AWS_ACCOUNT_ID>:role/<ROLE_NAME>
 ```
-where `<AWS_ACCOUNT_ID>` should be replaced witth your AWS account ID, and `<ROLE_NAME>` should be replaced with the name of the role granting access to the ECR.
+where `<AWS_ACCOUNT_ID>` should be replaced with your AWS account ID, and `<ROLE_NAME>` should be replaced with the name of the role granting access to the ECR.
 
 This will now allow the Trivy plugin to scan your internal images for vulnerabilities.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,7 +88,8 @@ nav:
           - Retain issues: configuration/retain-issues.md
           - Ignore unfixed vulnerabilities: plugins/trivy/#large-vulnerability-reports
           - HTTPS Proxy: configuration/https-proxy.md
-          - Scanning Images hosted in AWS Elastic Container Registry: configuration/aws-elastic-container-registry.md
+          - Scanning Images hosted in AWS ECR: configuration/aws-elastic-container-registry.md
+          - Scanning Images hosted in Azure ACR: configuration/acr.md
       - "🔌 Plugins":
           - Overview: plugins/index.md
           - Misconfiguration:


### PR DESCRIPTION
## Description
This PR add a documentation page with instructions for scanning private ACR images.

## How has this been tested?
- running the documentation steps into a AKS cluster with ACR images

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [ ] My changes are covered by tests
