### PR TITLE
Add Helm parameter for trivy timeout

### DIFF
--- a/charts/zora/README.md
+++ b/charts/zora/README.md
@@ -118,6 +118,7 @@ The following table lists the configurable parameters of the Zora chart and thei
 | scan.plugins.trivy.image.tag | string | `"0.48.2"` | trivy plugin image tag |
 | scan.plugins.trivy.env | list | `[]` | List of environment variables to set in trivy container. |
 | scan.plugins.trivy.envFrom | list | `[]` | List of sources to populate environment variables in trivy container. |
+| scan.plugins.trivy.timeout | string | `"10m"` | Trivy timeout |
 | scan.plugins.popeye.skipInternalResources | bool | `false` | Specifies whether the following resources should be skipped by `popeye` scans. 1. resources from `kube-system`, `kube-public` and `kube-node-lease` namespaces; 2. kubernetes system reserved RBAC (prefixed with `system:`); 3. `kube-root-ca.crt` configmaps; 4. `default` namespace; 5. `default` serviceaccounts; 6. Helm secrets (prefixed with `sh.helm.release`); 7. Zora components. See `popeye` configuration file that is used for this case: https://github.com/undistro/zora/blob/main/charts/zora/templates/plugins/popeye-config.yaml |
 | scan.plugins.popeye.resources | object | `{"limits":{"cpu":"500m","memory":"500Mi"},"requests":{"cpu":"250m","memory":"256Mi"}}` | [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) to add to `popeye` container |
 | scan.plugins.popeye.podAnnotations | object | `{}` | Annotations added to the popeye pods |

--- a/charts/zora/templates/plugins/trivy.yaml
+++ b/charts/zora/templates/plugins/trivy.yaml
@@ -61,6 +61,7 @@ spec:
         {{- if .Values.scan.plugins.trivy.ignoreUnfixed }}
         --ignore-unfixed \
         {{- end }}
+        --timeout={{ .Values.scan.plugins.trivy.timeout | quote }} \
         -o $(DONE_DIR)/results.json \
         cluster
 

--- a/charts/zora/values.yaml
+++ b/charts/zora/values.yaml
@@ -226,6 +226,8 @@ scan:
       envFrom: []
       #  - secretRef:
       #      name: trivy-credentials
+      # -- Trivy timeout
+      timeout: 10m
     popeye:
       # -- Specifies whether the following resources should be skipped by `popeye` scans.
       # 1. resources from `kube-system`, `kube-public` and `kube-node-lease` namespaces;

--- a/docs/plugins/trivy.md
+++ b/docs/plugins/trivy.md
@@ -31,3 +31,18 @@ The `ClusterScan` will have a `Failed` status. You will see a log entry similar 
 ```
 2023-09-26T14:18:02Z	ERROR	worker	failed to run worker	{"error": "failed to create VulnerabilityReport \"kind-kind-usdockerpkgdevgooglesamplescontainersgkegbfrontendsha256dc8de8e0d569d2f828b187528c9317bd6b605c273ac5a282aebe471f630420fc-rzntw\": etcdserver: request is too large"}
 ```
+
+## Scan timeout
+
+Trivy's scan duration may vary depending on the total images in your cluster 
+and the time to download the vulnerability database during each scan. 
+
+By default, Zora sets a timeout of **10 minutes** for Trivy scan completion.
+
+To adjust this timeout, use the following Helm parameter:
+
+```shell
+--set scan.plugins.trivy.timeout=15m
+```
+
+Once this parameter is updated, the next scan will use the specified value.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,6 +90,7 @@ nav:
           - HTTPS Proxy: configuration/https-proxy.md
           - Scanning Images hosted in AWS ECR: configuration/aws-elastic-container-registry.md
           - Scanning Images hosted in Azure ACR: configuration/acr.md
+          - Vulnerability scan timeout: plugins/trivy/#scan-timeout
       - "🔌 Plugins":
           - Overview: plugins/index.md
           - Misconfiguration:


### PR DESCRIPTION
## Description
This PR add a helm parameter for Trivy timeout and document it.

## How has this been tested?
- `helm template zora charts/zora --set clusterName=mycluster`
- `helm template zora charts/zora --set clusterName=mycluster --set scan.plugins.trivy.timeout=15m`

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [ ] My changes are covered by tests
