### PR TITLE
Avoid updating scans schedule on helm upgrades when not explicitly set

### DIFF
--- a/charts/zora/templates/clusterscan/clusterscan.yaml
+++ b/charts/zora/templates/clusterscan/clusterscan.yaml
@@ -30,12 +30,17 @@ metadata:
   labels:
     zora.undistro.io/default: "true"
     {{- include "zora.labels" . | nindent 4 }}
-  name: {{ include "truncate.name" (dict "name" (printf "%s-misconfig" (include "zora.clusterName" .)) "len" 63 ) }}
-
+  {{- $misconfigScanName := include "truncate.name" (dict "name" (printf "%s-misconfig" (include "zora.clusterName" .)) "len" 63 ) }}
+  name: {{ $misconfigScanName }}
 spec:
   clusterRef:
     name: {{ include "zora.clusterName" . }}
+  {{- $currentMisconfigScan := (lookup "zora.undistro.io/v1alpha1" "ClusterScan" .Release.Namespace $misconfigScanName) }}
+  {{- if and $currentMisconfigScan (not .Values.scan.misconfiguration.schedule) }}
+  schedule: {{ $currentMisconfigScan.spec.schedule | quote }}
+  {{- else }}
   schedule: {{ include "zora.misconfigSchedule" . | quote }}
+  {{- end }}
   successfulScansHistoryLimit: {{ .Values.scan.misconfiguration.successfulScansHistoryLimit }}
   {{- if .Values.scan.misconfiguration.plugins }}
   plugins:
@@ -52,11 +57,17 @@ metadata:
   labels:
     zora.undistro.io/default: "true"
     {{- include "zora.labels" . | nindent 4 }}
-  name: {{ include "truncate.name" (dict "name" (printf "%s-vuln" (include "zora.clusterName" .)) "len" 63 ) }}
+  {{- $vulnScanName := include "truncate.name" (dict "name" (printf "%s-vuln" (include "zora.clusterName" .)) "len" 63 ) }}
+  name: {{ $vulnScanName }}
 spec:
   clusterRef:
     name: {{ include "zora.clusterName" . }}
+  {{- $currentVulnScan := (lookup "zora.undistro.io/v1alpha1" "ClusterScan" .Release.Namespace $vulnScanName) }}
+  {{- if and $currentVulnScan (not .Values.scan.vulnerability.schedule) }}
+  schedule: {{ $currentVulnScan.spec.schedule | quote }}
+  {{- else }}
   schedule: {{ include "zora.vulnSchedule" . | quote }}
+  {{- end }}
   successfulScansHistoryLimit: {{ .Values.scan.vulnerability.successfulScansHistoryLimit }}
   {{- if .Values.scan.vulnerability.plugins }}
   plugins:


### PR DESCRIPTION
## Description
These changes avoid updates scans schedule on helm upgrades, when schedules are not set.

## How has this been tested?
These changes can be tested with `helm template --dry-run=server` or `helm upgrade --install` commands in clusters without Zora installed and clusters with Zora already installed.

- For clusters without Zora installed, the behavior should keep the same: if a scan schedule is explicitly set, use it; otherwise use a default value with 5 minutes added.
- For clusters with Zora already installed, the schedules should not be updated unless it's explicitly set.

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [ ] My changes are covered by tests
