### PR TITLE
UD-1211: Switch trivy image over to the undistro spin

### DIFF
--- a/charts/zora/README.md
+++ b/charts/zora/README.md
@@ -114,8 +114,8 @@ The following table lists the configurable parameters of the Zora chart and thei
 | scan.plugins.trivy.ignoreDescriptions | bool | `false` | Specifies whether vulnerability descriptions should be ignored |
 | scan.plugins.trivy.resources | object | `{}` | [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) to add to `trivy` container |
 | scan.plugins.trivy.podAnnotations | object | `{}` | Annotations added to the trivy pods |
-| scan.plugins.trivy.image.repository | string | `"ghcr.io/aquasecurity/trivy"` | trivy plugin image repository |
-| scan.plugins.trivy.image.tag | string | `"0.49.1"` | trivy plugin image tag |
+| scan.plugins.trivy.image.repository | string | `"ghcr.io/undistro/trivy"` | trivy plugin image repository |
+| scan.plugins.trivy.image.tag | string | `"0.49.1-3"` | trivy plugin image tag |
 | scan.plugins.trivy.env | list | `[]` | List of environment variables to set in trivy container. |
 | scan.plugins.trivy.envFrom | list | `[]` | List of sources to populate environment variables in trivy container. |
 | scan.plugins.trivy.timeout | string | `"10m"` | Trivy timeout |

--- a/charts/zora/values.yaml
+++ b/charts/zora/values.yaml
@@ -207,9 +207,9 @@ scan:
       podAnnotations: {}
       image:
         # -- trivy plugin image repository
-        repository: ghcr.io/aquasecurity/trivy
+        repository: ghcr.io/undistro/trivy
         # -- trivy plugin image tag
-        tag: 0.49.1
+        tag: 0.49.1-3
       # -- List of environment variables to set in trivy container.
       env: []
       #  - name: AWS_REGION

--- a/config/samples/zora_v1alpha1_plugin_trivy.yaml
+++ b/config/samples/zora_v1alpha1_plugin_trivy.yaml
@@ -10,7 +10,7 @@ metadata:
   name: trivy
 spec:
   type: vulnerability
-  image: ghcr.io/aquasecurity/trivy:0.49.1
+  image: ghcr.io/undistro/trivy:0.49.1-3
   securityContext:
     allowPrivilegeEscalation: false
   env:

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -17,7 +17,7 @@ kubectl get plugins -n zora-system
 NAME     IMAGE                               TYPE               AGE
 marvin   ghcr.io/undistro/marvin:v0.2.1      misconfiguration   14m
 popeye   ghcr.io/undistro/popeye:v0.11.3     misconfiguration   14m
-trivy    ghcr.io/aquasecurity/trivy:0.49.1   vulnerability      14m
+trivy    ghcr.io/undistro/trivy:0.49.1-3     vulnerability      14m
 ```
 
 Each item listed above is an instance of `Plugin` CRD and represents the execution configuration of a plugin.

--- a/docs/plugins/trivy.md
+++ b/docs/plugins/trivy.md
@@ -11,7 +11,7 @@ in different targets like containers, code repositories and **Kubernetes cluster
 
 :octicons-codescan-24: **Type**: `vulnerability`
 
-:simple-docker: **Image**: `ghcr.io/aquasecurity/trivy:0.49.1`
+:simple-docker: **Image**: `ghcr.io/undistro/trivy:0.49.1-3`
 
 :simple-github: **GitHub repository**: [https://github.com/aquasecurity/trivy](https://github.com/aquasecurity/trivy){:target="_blank"}
 


### PR DESCRIPTION
## Description
Switch trivy image to our patched version, this fixes trivy's issue with handling multiple ECR regions.

## Linked Issues

## How has this been tested?
- Create AWS cluster with images deployed from multiple ECR regions
- Enable trivy scanning, checking output to ensure no errors
- Check console to ensure both ECR regions show images

## Checklist
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [ ] I have documented my code (if applicable)
- [ ] My changes are covered by tests

Terraform scripts will be attached shortly