### PR TITLE
warn about costly scan scheduling in Helm output

### DIFF
--- a/charts/zora/templates/NOTES.txt
+++ b/charts/zora/templates/NOTES.txt
@@ -15,3 +15,14 @@ Visit our documentation for in-depth information: https://zora-docs.undistro.io
 {{ if .Values.saas.workspaceID -}}
 Visit Zora Dashboard to explore your clusters and issues: {{ .Values.saas.server }}
 {{- end }}
+
+{{ if and .Values.scan.misconfiguration.schedule (include "zora.IsMisconfigScheduleMoreOftenThanHourly" .) -}}
+WARNING: The misconfiguration scan appears to be scheduled to run more frequently then hourly, you should be aware this
+         may lead to higher resource utilization and network traffic.
+{{- end }}
+
+{{ if and .Values.scan.vulnerability.schedule (include "zora.IsVulnScheduleMoreOftenThanDaily" .) -}}
+WARNING: The vulnerability scan appears to be scheduled to run more frequently then daily, potentially leading to
+         significant increases in networking costs and resource utilization. This is particularly relevant for
+         vulnerability scans, which involve downloading a vulnerability database and pulling images.
+{{- end }}

--- a/charts/zora/templates/NOTES.txt
+++ b/charts/zora/templates/NOTES.txt
@@ -16,13 +16,15 @@ Visit our documentation for in-depth information: https://zora-docs.undistro.io
 Visit Zora Dashboard to explore your clusters and issues: {{ .Values.saas.server }}
 {{- end }}
 
-{{ if and .Values.scan.misconfiguration.schedule (include "zora.IsMisconfigScheduleMoreOftenThanHourly" .) -}}
+{{- $warnMisconfig := and .Values.scan.misconfiguration.schedule (include "zora.IsMisconfigScheduleMoreOftenThanHourly" .) }}
+{{- if eq $warnMisconfig "true" }}
 WARNING: The misconfiguration scan appears to be scheduled to run more frequently than hourly, you should be aware this
          may lead to higher resource utilization and network traffic.
 {{- end }}
 
-{{ if and .Values.scan.vulnerability.schedule (include "zora.IsVulnScheduleMoreOftenThanDaily" .) -}}
+{{- $warVuln := and .Values.scan.vulnerability.schedule (include "zora.IsVulnScheduleMoreOftenThanDaily" .) }}
+{{- if eq $warVuln "true" }}
 WARNING: The vulnerability scan appears to be scheduled to run more frequently than daily, potentially leading to
          significant increases in networking costs and resource utilization. This is particularly relevant for
          vulnerability scans, which involve downloading a vulnerability database and pulling images.
-{{- end }}
+{{ end }}

--- a/charts/zora/templates/NOTES.txt
+++ b/charts/zora/templates/NOTES.txt
@@ -17,12 +17,12 @@ Visit Zora Dashboard to explore your clusters and issues: {{ .Values.saas.server
 {{- end }}
 
 {{ if and .Values.scan.misconfiguration.schedule (include "zora.IsMisconfigScheduleMoreOftenThanHourly" .) -}}
-WARNING: The misconfiguration scan appears to be scheduled to run more frequently then hourly, you should be aware this
+WARNING: The misconfiguration scan appears to be scheduled to run more frequently than hourly, you should be aware this
          may lead to higher resource utilization and network traffic.
 {{- end }}
 
 {{ if and .Values.scan.vulnerability.schedule (include "zora.IsVulnScheduleMoreOftenThanDaily" .) -}}
-WARNING: The vulnerability scan appears to be scheduled to run more frequently then daily, potentially leading to
+WARNING: The vulnerability scan appears to be scheduled to run more frequently than daily, potentially leading to
          significant increases in networking costs and resource utilization. This is particularly relevant for
          vulnerability scans, which involve downloading a vulnerability database and pulling images.
 {{- end }}

--- a/charts/zora/templates/_helpers.tpl
+++ b/charts/zora/templates/_helpers.tpl
@@ -130,3 +130,22 @@ Truncate a name to a specific length
 {{- .name }}
 {{- end }}
 {{- end }}
+
+{{/* Returns true if the explicitly set misconfiguration schedule is more frequently than hourly */}}
+{{- define "zora.IsMisconfigScheduleMoreOftenThanHourly" -}}
+{{- $cron_fields := split " " .Values.scan.misconfiguration.schedule -}}
+{{- $minute := $cron_fields._0 -}}
+{{/* minute must be in range [0-59] */}}
+{{- not (mustRegexMatch "^(?:\\d|[0-5]\\d)$" $minute) -}}
+{{- end -}}
+
+{{/* Returns true if the explicitly set vulnerability schedule is more frequently than daily */}}
+{{- define "zora.IsVulnScheduleMoreOftenThanDaily" -}}
+{{- $cron_fields := split " " .Values.scan.vulnerability.schedule -}}
+{{- $minute := $cron_fields._0 -}}
+{{- $hour := $cron_fields._1 -}}
+{{/* minute and hour must be in range [0-59] */}}
+{{- $isMinuteBad := not (mustRegexMatch "^(?:\\d|[0-5]\\d)$" $minute) -}}
+{{- $isHourBad := not (mustRegexMatch "^(?:\\d|[0-5]\\d)$" $hour) -}}
+{{- or $isMinuteBad $isHourBad -}}
+{{- end -}}

--- a/charts/zora/templates/clusterscan/clusterscan.yaml
+++ b/charts/zora/templates/clusterscan/clusterscan.yaml
@@ -35,7 +35,7 @@ metadata:
 spec:
   clusterRef:
     name: {{ include "zora.clusterName" . }}
-  {{- $currentMisconfigScan := (lookup "zora.undistro.io/v1alpha1" "ClusterScan" .Release.Namespace $misconfigScanName) }}
+  {{- $currentMisconfigScan := and (.Capabilities.APIVersions.Has "zora.undistro.io/v1alpha1") (lookup "zora.undistro.io/v1alpha1" "ClusterScan" .Release.Namespace $misconfigScanName) }}
   {{- if and $currentMisconfigScan (not .Values.scan.misconfiguration.schedule) }}
   schedule: {{ $currentMisconfigScan.spec.schedule | quote }}
   {{- else }}
@@ -62,7 +62,7 @@ metadata:
 spec:
   clusterRef:
     name: {{ include "zora.clusterName" . }}
-  {{- $currentVulnScan := (lookup "zora.undistro.io/v1alpha1" "ClusterScan" .Release.Namespace $vulnScanName) }}
+  {{- $currentVulnScan := and (.Capabilities.APIVersions.Has "zora.undistro.io/v1alpha1") (lookup "zora.undistro.io/v1alpha1" "ClusterScan" .Release.Namespace $vulnScanName) }}
   {{- if and $currentVulnScan (not .Values.scan.vulnerability.schedule) }}
   schedule: {{ $currentVulnScan.spec.schedule | quote }}
   {{- else }}


### PR DESCRIPTION
## Description
This PR includes a warning in the Helm output if a scan appears to be scheduled to run more frequently than the recommendation.

It also fixes the helm template for ClusterScans, checking the API Version before calling the lookup function.

## How has this been tested?
Trying installing Zora with different schedules for each scan.
```shell
helm upgrade --install zora charts/zora/ -f /tmp/values.yaml -n zora-system --create-namespace
```
This is the `values.yaml`:
```yaml
clusterName: kind
scan:
  # misconfiguration:
  vulnerability:
    # At every minute
    # schedule: "* * * * *"
    
    # At every minute on Wednesday
    # schedule: "* * * * 4"
    
    # At 00:00 on Wednesday (weekly)
    # schedule: "0 0 * * 4"
    
    # At 00:00 on day-of-month 1 (monthly)
    # schedule: "0 0 1 * *"
    
    # At every minute on day-of-month 1
    # schedule: "* * 1 * *"

    # Every hour at every 30th minute
    # schedule: "*/30 * * * *"

    # Every hour at every minute (range of values)
    # schedule: "0-59 * * * *"

    # Every hour at minute 15 and 45
    # schedule: "15,45 * * * *"

    # Every hour at minute 0
    # schedule: "0 * * * *"

    # At minute 0 past hour 12 and 18
    # schedule: "0 12,18 * * *"

    # At 10:00
    # schedule: "0 10 * * *"

    # Every hour at minute 0 on day-of-month 5
    schedule: "0 * 5 * *"
```

Unfortunately helm template does not render NOTES.txt (https://github.com/helm/helm/issues/6901)

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [ ] My changes are covered by tests
