### PR TITLE
Update popeye worker integration for version v0.21.0

### DIFF
--- a/charts/zora/README.md
+++ b/charts/zora/README.md
@@ -124,7 +124,7 @@ The following table lists the configurable parameters of the Zora chart and thei
 | scan.plugins.popeye.resources | object | `{"limits":{"cpu":"500m","memory":"500Mi"},"requests":{"cpu":"250m","memory":"256Mi"}}` | [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) to add to `popeye` container |
 | scan.plugins.popeye.podAnnotations | object | `{}` | Annotations added to the popeye pods |
 | scan.plugins.popeye.image.repository | string | `"ghcr.io/undistro/popeye"` | popeye plugin image repository |
-| scan.plugins.popeye.image.tag | string | `"v0.11.3"` | popeye plugin image tag |
+| scan.plugins.popeye.image.tag | string | `"0.21.1-4"` | popeye plugin image tag |
 | scan.plugins.popeye.env | list | `[]` | List of environment variables to set in popeye container. |
 | scan.plugins.popeye.envFrom | list | `[]` | List of sources to populate environment variables in popeye container. |
 | kubexnsImage.repository | string | `"ghcr.io/undistro/kubexns"` | kubexns image repository |

--- a/charts/zora/values.yaml
+++ b/charts/zora/values.yaml
@@ -254,7 +254,7 @@ scan:
         # -- popeye plugin image repository
         repository: ghcr.io/undistro/popeye
         # -- popeye plugin image tag
-        tag: v0.11.3
+        tag: 0.21.1-4
       # -- List of environment variables to set in popeye container.
       env: []
       # -- List of sources to populate environment variables in popeye container.

--- a/config/samples/zora_v1alpha1_plugin_popeye.yaml
+++ b/config/samples/zora_v1alpha1_plugin_popeye.yaml
@@ -10,7 +10,7 @@ metadata:
   name: popeye
 spec:
   type: misconfiguration
-  image: ghcr.io/undistro/popeye:v0.11.3
+  image: ghcr.io/undistro/popeye:0.21.1-4
   resources:
     limits:
       cpu: 500m

--- a/config/samples/zora_v1alpha1_plugin_popeye_all.yaml
+++ b/config/samples/zora_v1alpha1_plugin_popeye_all.yaml
@@ -10,7 +10,7 @@ metadata:
   name: popeye
 spec:
   type: misconfiguration
-  image: ghcr.io/undistro/popeye:v0.11.3
+  image: ghcr.io/undistro/popeye:0.21.1-4
   resources:
     limits:
       cpu: 500m

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -16,7 +16,7 @@ kubectl get plugins -n zora-system
 ```
 NAME     IMAGE                               TYPE               AGE
 marvin   ghcr.io/undistro/marvin:v0.2.1      misconfiguration   14m
-popeye   ghcr.io/undistro/popeye:v0.11.3     misconfiguration   14m
+popeye   ghcr.io/undistro/popeye:0.21.1-4    misconfiguration   14m
 trivy    ghcr.io/undistro/trivy:0.49.1-3     vulnerability      14m
 ```
 

--- a/docs/plugins/popeye.md
+++ b/docs/plugins/popeye.md
@@ -8,7 +8,7 @@ Popeye is a utility that scans live Kubernetes cluster and reports potential iss
 
 :octicons-codescan-24: **Type**: `misconfiguration`
 
-:simple-docker: **Image**: `ghcr.io/undistro/popeye:v0.11.3`
+:simple-docker: **Image**: `ghcr.io/undistro/popeye:0.21.1-4`
 
 :simple-github: **GitHub repository**: [https://github.com/derailed/popeye](https://github.com/derailed/popeye){:target="_blank"}
 

--- a/pkg/worker/report/popeye/parse.go
+++ b/pkg/worker/report/popeye/parse.go
@@ -59,8 +59,8 @@ func Parse(ctx context.Context, results io.Reader) ([]v1alpha1.ClusterIssueSpec,
 		return nil, err
 	}
 	issuesByID := map[string]*v1alpha1.ClusterIssueSpec{}
-	for _, sanitizer := range report.Popeye.Sanitizers {
-		for typ, issues := range sanitizer.Issues {
+	for _, linter := range report.Popeye.Sections {
+		for typ, issues := range linter.Issues {
 			if typ == "" {
 				if len(issues) > 0 {
 					if msg := issues[0].Message; strings.Contains(msg, "forbidden") {
@@ -81,7 +81,7 @@ func Parse(ctx context.Context, results io.Reader) ([]v1alpha1.ClusterIssueSpec,
 					continue
 				}
 				if ci, ok := issuesByID[id]; ok {
-					ci.AddResource(sanitizer.GVR, typ)
+					ci.AddResource(linter.GVR, typ)
 				} else {
 					spec := &v1alpha1.ClusterIssueSpec{
 						ID:             id,
@@ -95,7 +95,7 @@ func Parse(ctx context.Context, results io.Reader) ([]v1alpha1.ClusterIssueSpec,
 					}
 					if !clusterScoped {
 						spec.TotalResources = 1
-						spec.Resources = map[string][]string{sanitizer.GVR: {typ}}
+						spec.Resources = map[string][]string{linter.GVR: {typ}}
 					}
 					issuesByID[id] = spec
 				}

--- a/pkg/worker/report/popeye/popeye_types.go
+++ b/pkg/worker/report/popeye/popeye_types.go
@@ -30,22 +30,22 @@ const (
 	ErrorLevel
 )
 
-// Issue represents a Popeye sanitizer issue.
+// Issue represents a Popeye linter issue.
 type Issue struct {
 	Level   Level  `json:"level"`
 	Message string `json:"message"`
 }
 
-// Sanitizer represents a Popeye sanitizer.
-type Sanitizer struct {
-	Sanitizer string             `json:"sanitizer"`
-	GVR       string             `json:"gvr"`
-	Issues    map[string][]Issue `json:"issues"`
+// Sanitizer represents a Popeye linter.
+type Section struct {
+	Linter string             `json:"linter"`
+	GVR    string             `json:"gvr"`
+	Issues map[string][]Issue `json:"issues"`
 }
 
 // Popeye represents a Popeye report.
 type Popeye struct {
-	Sanitizers []Sanitizer `json:"sanitizers"`
+	Sections []Section `json:"sections"`
 }
 
 // Report wraps a Popeye report.

--- a/pkg/worker/report/popeye/testdata/test_report_1.json
+++ b/pkg/worker/report/popeye/testdata/test_report_1.json
@@ -1,12 +1,12 @@
 {
   "popeye": {
-    "sanitizers": [
+    "sections": [
       {
-        "sanitizer": "cluster",
+        "linter": "cluster",
         "gvr": "cluster"
       },
       {
-        "sanitizer": "clusterroles",
+        "linter": "clusterroles",
         "gvr": "rbac.authorization.k8s.io/v1/clusterroles",
         "issues": {
           "admin": [

--- a/pkg/worker/report/popeye/testdata/test_report_2.json
+++ b/pkg/worker/report/popeye/testdata/test_report_2.json
@@ -1,8 +1,8 @@
 {
   "popeye": {
-    "sanitizers": [
+    "sections": [
       {
-        "sanitizer": "clusterroles",
+        "linter": "clusterroles",
         "gvr": "rbac.authorization.k8s.io/v1/clusterroles",
         "issues": {
           "system:node": [],
@@ -21,7 +21,7 @@
         }
       },
       {
-        "sanitizer": "daemonsets",
+        "linter": "daemonsets",
         "gvr": "apps/v1/daemonsets",
         "issues": {
           "kube-system/aws-node": [
@@ -43,7 +43,7 @@
         }
       },
       {
-        "sanitizer": "deployments",
+        "linter": "deployments",
         "gvr": "apps/v1/deployments",
         "issues": {
           "cert-manager/cert-manager": [
@@ -59,7 +59,7 @@
         }
       },
       {
-        "sanitizer": "cluster",
+        "linter": "cluster",
         "gvr": "cluster",
         "issues": {
           "Version": [
@@ -73,7 +73,7 @@
         }
       },
       {
-        "sanitizer": "pods",
+        "linter": "pods",
         "gvr": "v1/pods",
         "issues": {
           "kube-system/cilium-jxncv": [

--- a/pkg/worker/report/popeye/testdata/test_report_5.json
+++ b/pkg/worker/report/popeye/testdata/test_report_5.json
@@ -2,9 +2,9 @@
   "popeye": {
     "score": 85,
     "grade": "B",
-    "sanitizers": [
+    "sections": [
       {
-        "sanitizer": "nodes",
+        "linter": "nodes",
         "gvr": "v1/nodes",
         "tally": {
           "ok": 0,
@@ -25,7 +25,7 @@
         }
       },
       {
-        "sanitizer": "poddisruptionbudgets",
+        "linter": "poddisruptionbudgets",
         "gvr": "policy/v1/poddisruptionbudgets",
         "tally": {
           "ok": 0,

--- a/pkg/worker/report/popeye/testdata/test_report_6.json
+++ b/pkg/worker/report/popeye/testdata/test_report_6.json
@@ -2,9 +2,9 @@
   "popeye": {
     "score": 13,
     "grade": "F",
-    "sanitizers": [
+    "sections": [
       {
-        "sanitizer": "cluster",
+        "linter": "cluster",
         "gvr": "cluster",
         "tally": {
           "ok": 1,
@@ -25,7 +25,7 @@
         }
       },
       {
-        "sanitizer": "clusterroles",
+        "linter": "clusterroles",
         "gvr": "rbac.authorization.k8s.io/v1/clusterroles",
         "tally": {
           "ok": 0,
@@ -52,7 +52,7 @@
         }
       },
       {
-        "sanitizer": "clusterrolebindings",
+        "linter": "clusterrolebindings",
         "gvr": "rbac.authorization.k8s.io/v1/clusterrolebindings",
         "tally": {
           "ok": 0,
@@ -63,7 +63,7 @@
         }
       },
       {
-        "sanitizer": "configmaps",
+        "linter": "configmaps",
         "gvr": "v1/configmaps",
         "tally": {
           "ok": 0,
@@ -84,7 +84,7 @@
         }
       },
       {
-        "sanitizer": "daemonsets",
+        "linter": "daemonsets",
         "gvr": "apps/v1/daemonsets",
         "tally": {
           "ok": 0,
@@ -105,7 +105,7 @@
         }
       },
       {
-        "sanitizer": "deployments",
+        "linter": "deployments",
         "gvr": "apps/v1/deployments",
         "tally": {
           "ok": 0,
@@ -126,7 +126,7 @@
         }
       },
       {
-        "sanitizer": "horizontalpodautoscalers",
+        "linter": "horizontalpodautoscalers",
         "gvr": "autoscaling/v2/horizontalpodautoscalers",
         "tally": {
           "ok": 0,
@@ -147,7 +147,7 @@
         }
       },
       {
-        "sanitizer": "ingresses",
+        "linter": "ingresses",
         "gvr": "networking.k8s.io/v1/ingresses",
         "tally": {
           "ok": 0,
@@ -168,7 +168,7 @@
         }
       },
       {
-        "sanitizer": "namespaces",
+        "linter": "namespaces",
         "gvr": "v1/namespaces",
         "tally": {
           "ok": 0,
@@ -189,7 +189,7 @@
         }
       },
       {
-        "sanitizer": "networkpolicies",
+        "linter": "networkpolicies",
         "gvr": "networking.k8s.io/v1/networkpolicies",
         "tally": {
           "ok": 0,
@@ -210,7 +210,7 @@
         }
       },
       {
-        "sanitizer": "nodes",
+        "linter": "nodes",
         "gvr": "v1/nodes",
         "tally": {
           "ok": 0,
@@ -231,7 +231,7 @@
         }
       },
       {
-        "sanitizer": "persistentvolumes",
+        "linter": "persistentvolumes",
         "gvr": "v1/persistentvolumes",
         "tally": {
           "ok": 0,
@@ -258,7 +258,7 @@
         }
       },
       {
-        "sanitizer": "persistentvolumeclaims",
+        "linter": "persistentvolumeclaims",
         "gvr": "v1/persistentvolumeclaims",
         "tally": {
           "ok": 0,
@@ -279,7 +279,7 @@
         }
       },
       {
-        "sanitizer": "pods",
+        "linter": "pods",
         "gvr": "v1/pods",
         "tally": {
           "ok": 0,
@@ -290,7 +290,7 @@
         }
       },
       {
-        "sanitizer": "poddisruptionbudgets",
+        "linter": "poddisruptionbudgets",
         "gvr": "policy/v1/poddisruptionbudgets",
         "tally": {
           "ok": 0,
@@ -311,7 +311,7 @@
         }
       },
       {
-        "sanitizer": "replicasets",
+        "linter": "replicasets",
         "gvr": "apps/v1/replicasets",
         "tally": {
           "ok": 0,
@@ -332,7 +332,7 @@
         }
       },
       {
-        "sanitizer": "roles",
+        "linter": "roles",
         "gvr": "rbac.authorization.k8s.io/v1/roles",
         "tally": {
           "ok": 0,
@@ -353,7 +353,7 @@
         }
       },
       {
-        "sanitizer": "rolebindings",
+        "linter": "rolebindings",
         "gvr": "rbac.authorization.k8s.io/v1/rolebindings",
         "tally": {
           "ok": 0,
@@ -374,7 +374,7 @@
         }
       },
       {
-        "sanitizer": "secrets",
+        "linter": "secrets",
         "gvr": "v1/secrets",
         "tally": {
           "ok": 0,
@@ -395,7 +395,7 @@
         }
       },
       {
-        "sanitizer": "services",
+        "linter": "services",
         "gvr": "v1/services",
         "tally": {
           "ok": 0,
@@ -422,7 +422,7 @@
         }
       },
       {
-        "sanitizer": "serviceaccounts",
+        "linter": "serviceaccounts",
         "gvr": "v1/serviceaccounts",
         "tally": {
           "ok": 0,
@@ -443,7 +443,7 @@
         }
       },
       {
-        "sanitizer": "statefulsets",
+        "linter": "statefulsets",
         "gvr": "apps/v1/statefulsets",
         "tally": {
           "ok": 0,

--- a/pkg/worker/report/popeye/testdata/test_report_7.json
+++ b/pkg/worker/report/popeye/testdata/test_report_7.json
@@ -2,9 +2,9 @@
   "popeye": {
     "score": 13,
     "grade": "F",
-    "sanitizers": [
+    "sections": [
       {
-        "sanitizer": "cluster",
+        "linter": "cluster",
         "gvr": "cluster",
         "tally": {
           "ok": 1,


### PR DESCRIPTION
## Description
This PR updates the zora worker popeye integration to support the reports generated in version v0.21.0.  The PR also switches the helm charts over to our build of popeye, which is currently 0.21.1-4.

## Linked Issues

## How has this been tested?
- Building the worker and deploying to a cluster
- Verifying popeye image is using our build
- Run scan, verify both worker and popeye containers to make sure the runs are clean
- Check issues to ensure they are created.

## Checklist
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [ ] I have documented my code (if applicable)
- [X] My changes are covered by tests
