### PR TITLE
UD-1338: Update trivy to 0.50.0

### DIFF
--- a/charts/zora/README.md
+++ b/charts/zora/README.md
@@ -115,7 +115,7 @@ The following table lists the configurable parameters of the Zora chart and thei
 | scan.plugins.trivy.resources | object | `{}` | [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) to add to `trivy` container |
 | scan.plugins.trivy.podAnnotations | object | `{}` | Annotations added to the trivy pods |
 | scan.plugins.trivy.image.repository | string | `"ghcr.io/undistro/trivy"` | trivy plugin image repository |
-| scan.plugins.trivy.image.tag | string | `"0.49.1-3"` | trivy plugin image tag |
+| scan.plugins.trivy.image.tag | string | `"0.50.0-1"` | trivy plugin image tag |
 | scan.plugins.trivy.env | list | `[]` | List of environment variables to set in trivy container. |
 | scan.plugins.trivy.envFrom | list | `[]` | List of sources to populate environment variables in trivy container. |
 | scan.plugins.trivy.timeout | string | `"10m"` | Trivy timeout |

--- a/charts/zora/values.yaml
+++ b/charts/zora/values.yaml
@@ -209,7 +209,7 @@ scan:
         # -- trivy plugin image repository
         repository: ghcr.io/undistro/trivy
         # -- trivy plugin image tag
-        tag: 0.49.1-3
+        tag: 0.50.0-1
       # -- List of environment variables to set in trivy container.
       env: []
       #  - name: AWS_REGION

--- a/config/samples/zora_v1alpha1_plugin_trivy.yaml
+++ b/config/samples/zora_v1alpha1_plugin_trivy.yaml
@@ -10,7 +10,7 @@ metadata:
   name: trivy
 spec:
   type: vulnerability
-  image: ghcr.io/undistro/trivy:0.49.1-3
+  image: ghcr.io/undistro/trivy:0.50.0-1
   securityContext:
     allowPrivilegeEscalation: false
   env:

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -17,7 +17,7 @@ kubectl get plugins -n zora-system
 NAME     IMAGE                               TYPE               AGE
 marvin   ghcr.io/undistro/marvin:v0.2.1      misconfiguration   14m
 popeye   ghcr.io/undistro/popeye:0.21.1-4    misconfiguration   14m
-trivy    ghcr.io/undistro/trivy:0.49.1-3     vulnerability      14m
+trivy    ghcr.io/undistro/trivy:0.50.0-1     vulnerability      14m
 ```
 
 Each item listed above is an instance of `Plugin` CRD and represents the execution configuration of a plugin.

--- a/docs/plugins/trivy.md
+++ b/docs/plugins/trivy.md
@@ -11,7 +11,7 @@ in different targets like containers, code repositories and **Kubernetes cluster
 
 :octicons-codescan-24: **Type**: `vulnerability`
 
-:simple-docker: **Image**: `ghcr.io/undistro/trivy:0.49.1-3`
+:simple-docker: **Image**: `ghcr.io/undistro/trivy:0.50.0-1`
 
 :simple-github: **GitHub repository**: [https://github.com/aquasecurity/trivy](https://github.com/aquasecurity/trivy){:target="_blank"}
 


### PR DESCRIPTION
## Description
Update Trivy support to 0.50.0, now using image `ghcr.io/undistro/trivy:0.50.0-1`

## Linked Issues

## How has this been tested?
- Deploy new trivy image to cluster
- Ensure scan runs cleanly (worker and trivy container)
- Check vulnerabilities are created in the `zora-system` namespace
- Check vulnerabilities are registered in the console.

## Checklist
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [X] I have documented my code (if applicable)
- [ ] My changes are covered by tests
