### PR TITLE
ci: update docs automatically on push to main

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -15,9 +15,6 @@ on:
       latest:
         description: 'latest'
         type: boolean
-      dev:
-        description: 'dev'
-        type: boolean
 
 env:
   GIT_USER: "github-actions"
@@ -54,7 +51,7 @@ jobs:
       - name: mike deploy
         env:
           VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || 'dev' }}
-          ALIAS: ${{ inputs.latest && 'latest' || inputs.dev && 'dev' || '' }}
+          ALIAS: ${{ inputs.latest && 'latest' || '' }}
         run: |
           cp -f charts/zora/README.md docs/helm-chart.md
           cp -f charts/zora/values.yaml docs/values.yaml

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,5 +1,12 @@
 name: docs
 on:
+  push:
+    branches: [ 'main' ]
+    paths:
+      - 'docs/**'
+      - 'charts/zora/Chart.yaml'
+      - 'charts/zora/values.yaml'
+      - 'charts/zora/README.md'
   workflow_dispatch:
     inputs:
       version:
@@ -39,14 +46,6 @@ jobs:
       - name: install mkdocs and mike
         run: pip install mkdocs-material mike
 
-      - name: set 'latest' alias
-        if: inputs.latest
-        run: echo 'alias=latest' >> $GITHUB_ENV
-
-      - name: set 'dev' alias
-        if: inputs.dev
-        run: echo 'alias=dev' >> $GITHUB_ENV
-
       - name: fetch gh-pages branch
         run: |
           git config --global user.email "$GIT_EMAIL"
@@ -54,10 +53,13 @@ jobs:
           git fetch origin gh-pages --depth=1
 
       - name: mike deploy
+        env:
+          VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || 'main' }}
+          ALIAS: ${{ inputs.latest && 'latest' || 'dev' }}
         run: |
           cp -f charts/zora/README.md docs/helm-chart.md
           cp -f charts/zora/values.yaml docs/values.yaml
-          mike deploy --update-aliases ${{ inputs.version }} ${{ env.alias }}
+          mike deploy --update-aliases $VERSION $ALIAS
 
       - name: update titles and push
         run: |

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -4,7 +4,6 @@ on:
     branches: [ 'main' ]
     paths:
       - 'docs/**'
-      - 'charts/zora/Chart.yaml'
       - 'charts/zora/values.yaml'
       - 'charts/zora/README.md'
   workflow_dispatch:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -53,7 +53,7 @@ jobs:
 
       - name: mike deploy
         env:
-          VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || 'main' }}
+          VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || 'dev' }}
           ALIAS: ${{ inputs.latest && 'latest' || 'dev' }}
         run: |
           cp -f charts/zora/README.md docs/helm-chart.md

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: mike deploy
         env:
           VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || 'dev' }}
-          ALIAS: ${{ inputs.latest && 'latest' || 'dev' }}
+          ALIAS: ${{ inputs.latest && 'latest' || inputs.dev && 'dev' || '' }}
         run: |
           cp -f charts/zora/README.md docs/helm-chart.md
           cp -f charts/zora/values.yaml docs/values.yaml


### PR DESCRIPTION
## Description
This PR changes the `docs` workflow to update the documentation for a push to `main` branch that includes a change in `docs/` file.

This way documentation will always have a updated version with the latest changes. Then the `dev` check box for manual updates, is no longer necessary.

![image](https://github.com/undistro/zora/assets/16636449/8ae3c016-5ff1-4a33-8199-0be6aa6946c0)

## Linked Issues
UD-1345

## How has this been tested?
- Updating a file from `docs` directory.

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [ ] I have documented my code (if applicable)
- [ ] My changes are covered by tests
