### PR TITLE
Fix sum of issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,6 +155,9 @@ install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~
 	@$(KUBECTL) apply -f config/samples/zora_v1alpha1_customcheck_labels.yaml -n $(NAMESPACE)
 	@$(KUBECTL) apply -f config/rbac/zora_plugins_role.yaml
 	@$(KUBECTL) create -f config/rbac/zora_plugins_role_binding.yaml || true
+	@$(KUBECTL) apply -f config/samples/zora_v1alpha1_cluster.yaml -n $(NAMESPACE)
+	@$(KUBECTL) apply -f config/samples/zora_v1alpha1_clusterscan_misconfig.yaml -n $(NAMESPACE)
+	@$(KUBECTL) apply -f config/samples/zora_v1alpha1_clusterscan_vuln.yaml -n $(NAMESPACE)
 
 .PHONY: uninstall
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.

--- a/api/zora/v1alpha1/clusterscan_types.go
+++ b/api/zora/v1alpha1/clusterscan_types.go
@@ -311,6 +311,10 @@ func (in *ClusterScan) ClusterKey() types.NamespacedName {
 	return types.NamespacedName{Name: in.Spec.ClusterRef.Name, Namespace: in.Namespace}
 }
 
+func (in *ClusterScan) NamespacedName() types.NamespacedName {
+	return types.NamespacedName{Name: in.Name, Namespace: in.Namespace}
+}
+
 //+kubebuilder:object:root=true
 
 // ClusterScanList contains a list of ClusterScan

--- a/charts/zora/Chart.yaml
+++ b/charts/zora/Chart.yaml
@@ -17,7 +17,7 @@ name: zora
 description: A multi-plugin solution that reports misconfigurations and vulnerabilities by scanning your cluster at scheduled times.
 icon: https://zora-docs.undistro.io/v0.7/assets/logo.svg
 type: application
-version: 0.8.4-rc1
-appVersion: "v0.8.4-rc1"
+version: 0.8.4-rc3
+appVersion: "v0.8.4-rc3"
 sources:
   - https://github.com/undistro/zora

--- a/charts/zora/README.md
+++ b/charts/zora/README.md
@@ -1,6 +1,6 @@
 # Zora Helm Chart
 
-![Version: 0.8.4-rc1](https://img.shields.io/badge/Version-0.8.4--rc1-informational?style=flat-square&color=3CA9DD) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square&color=3CA9DD) ![AppVersion: v0.8.4-rc1](https://img.shields.io/badge/AppVersion-v0.8.4--rc1-informational?style=flat-square&color=3CA9DD)
+![Version: 0.8.4-rc3](https://img.shields.io/badge/Version-0.8.4--rc3-informational?style=flat-square&color=3CA9DD) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square&color=3CA9DD) ![AppVersion: v0.8.4-rc3](https://img.shields.io/badge/AppVersion-v0.8.4--rc3-informational?style=flat-square&color=3CA9DD)
 
 A multi-plugin solution that reports misconfigurations and vulnerabilities by scanning your cluster at scheduled times.
 
@@ -13,7 +13,7 @@ helm repo add undistro https://charts.undistro.io --force-update
 helm repo update undistro
 helm upgrade --install zora undistro/zora \
   -n zora-system \
-  --version 0.8.4-rc1 \
+  --version 0.8.4-rc3 \
   --create-namespace \
   --wait \
   --set clusterName="$(kubectl config current-context)"

--- a/config/samples/zora_v1alpha1_clusterscan_misconfig.yaml
+++ b/config/samples/zora_v1alpha1_clusterscan_misconfig.yaml
@@ -12,6 +12,7 @@ spec:
   clusterRef:
     name: mycluster
   schedule: "*/2 * * * *"
+  successfulScansHistoryLimit: 1
   plugins:
     - name: marvin
     - name: popeye

--- a/config/samples/zora_v1alpha1_clusterscan_vuln.yaml
+++ b/config/samples/zora_v1alpha1_clusterscan_vuln.yaml
@@ -12,5 +12,6 @@ spec:
   clusterRef:
     name: mycluster
   schedule: "*/10 * * * *"
+  successfulScansHistoryLimit: 1
   plugins:
     - name: trivy

--- a/internal/saas/clusters.go
+++ b/internal/saas/clusters.go
@@ -137,10 +137,16 @@ func NewCluster(cluster v1alpha1.Cluster) Cluster {
 func NewScanStatus(clusterScan *v1alpha1.ClusterScan, scans []v1alpha1.ClusterScan) (map[string]*PluginStatus, *int) {
 	var pluginStatus map[string]*PluginStatus
 	var totalIssues *int
-
-	allScans := []v1alpha1.ClusterScan{}
-	allScans = append(allScans, scans...)
-	allScans = append(allScans, *clusterScan)
+	allScans := make(map[string]v1alpha1.ClusterScan)
+	if clusterScan != nil {
+		allScans[clusterScan.NamespacedName().String()] = *clusterScan
+	}
+	for _, scan := range scans {
+		key := scan.NamespacedName().String()
+		if _, ok := allScans[key]; !ok {
+			allScans[key] = scan
+		}
+	}
 	for _, cs := range allScans {
 		if cs.Status.TotalIssues != nil {
 			if totalIssues == nil {

--- a/internal/saas/clusters_test.go
+++ b/internal/saas/clusters_test.go
@@ -16,11 +16,15 @@ package saas
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/yaml"
 
 	"github.com/undistro/zora/api/zora/v1alpha1"
@@ -122,4 +126,109 @@ func readClusterPayload(filename string) (Cluster, error) {
 		return cp, err
 	}
 	return cp, err
+}
+
+func TestNewScanStatus(t *testing.T) {
+	type args struct {
+		clusterScan *v1alpha1.ClusterScan
+		scans       []v1alpha1.ClusterScan
+	}
+	tests := []struct {
+		name            string
+		args            args
+		want            map[string]*PluginStatus
+		wantTotalIssues *int
+	}{
+		{
+			name: "current scan with 21 issues, previous with 19",
+			args: args{
+				clusterScan: &v1alpha1.ClusterScan{
+					ObjectMeta: metav1.ObjectMeta{Name: "mycluster-misconfig"},
+					Spec:       v1alpha1.ClusterScanSpec{Schedule: "17 * * * *"},
+					Status: v1alpha1.ClusterScanStatus{
+						TotalIssues:        pointer.Int(21),
+						LastScheduleTime:   mustParseTime("2024-03-28T14:17:00Z"),
+						LastFinishedTime:   mustParseTime("2024-03-28T14:17:27Z"),
+						LastSuccessfulTime: mustParseTime("2024-03-28T14:17:27Z"),
+						NextScheduleTime:   mustParseTime("2024-03-28T15:17:00Z"),
+						LastStatus:         "Complete",
+						LastFinishedStatus: "Complete",
+						Plugins: map[string]*v1alpha1.PluginScanStatus{
+							"marvin": {
+								LastScheduleTime:     mustParseTime("2024-03-28T14:17:00Z"),
+								LastFinishedTime:     mustParseTime("2024-03-28T14:17:27Z"),
+								LastSuccessfulTime:   mustParseTime("2024-03-28T14:17:27Z"),
+								NextScheduleTime:     mustParseTime("2024-03-28T15:17:00Z"),
+								LastScanID:           "9c6706f7-4d0e-4c79-bf70-efe1f4adc722",
+								LastSuccessfulScanID: "9c6706f7-4d0e-4c79-bf70-efe1f4adc722",
+								LastStatus:           "Complete",
+								LastFinishedStatus:   "Complete",
+								TotalIssues:          pointer.Int(21),
+							},
+						},
+					},
+				},
+				scans: []v1alpha1.ClusterScan{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "mycluster-misconfig"},
+						Spec:       v1alpha1.ClusterScanSpec{Schedule: "17 * * * *"},
+						Status: v1alpha1.ClusterScanStatus{
+							TotalIssues:        pointer.Int(19),
+							LastScheduleTime:   mustParseTime("2024-03-28T14:17:00Z"),
+							LastFinishedTime:   nil,
+							LastSuccessfulTime: mustParseTime("2024-03-28T13:17:27Z"), // referring to the previous scan (1h before)
+							NextScheduleTime:   mustParseTime("2024-03-28T15:17:00Z"),
+							LastStatus:         "Active",
+							LastFinishedStatus: "Complete",
+							Plugins: map[string]*v1alpha1.PluginScanStatus{
+								"marvin": {
+									LastScheduleTime:     mustParseTime("2024-03-28T14:17:00Z"),
+									LastFinishedTime:     nil,
+									LastSuccessfulTime:   mustParseTime("2024-03-28T13:17:27Z"), // referring to the previous scan (1h before)
+									NextScheduleTime:     mustParseTime("2024-03-28T15:17:00Z"),
+									LastScanID:           "9c6706f7-4d0e-4c79-bf70-efe1f4adc722",
+									LastSuccessfulScanID: "3eadcc75-64c0-4498-a834-320c98a4da6c", // referring to the previous scan (1h before)
+									LastStatus:           "Active",
+									LastFinishedStatus:   "Complete",
+									TotalIssues:          pointer.Int(19),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: map[string]*PluginStatus{"marvin": {
+				Scan: &ScanStatus{
+					Status:  Scanned,
+					Suspend: false,
+					ID:      "9c6706f7-4d0e-4c79-bf70-efe1f4adc722",
+				},
+				IssueCount:             pointer.Int(21),
+				LastSuccessfulScanTime: mustParseTime("2024-03-28T14:17:27Z"),
+				LastFinishedScanTime:   mustParseTime("2024-03-28T14:17:27Z"),
+				NextScheduleScanTime:   mustParseTime("2024-03-28T15:17:00Z"),
+				Schedule:               "17 * * * *",
+				LastSuccessfulScanID:   "9c6706f7-4d0e-4c79-bf70-efe1f4adc722",
+			}},
+			wantTotalIssues: pointer.Int(21),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, totalIssues := NewScanStatus(tt.args.clusterScan, tt.args.scans)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewScanStatus() mismatch (-want +got):\n%s", cmp.Diff(tt.want, got))
+			}
+			if pointer.IntDeref(totalIssues, 0) == pointer.IntDeref(tt.wantTotalIssues, 0) {
+				t.Errorf("NewScanStatus() totalIssues = %v, want %v", totalIssues, tt.wantTotalIssues)
+			}
+		})
+	}
+}
+func mustParseTime(v string) *metav1.Time {
+	t, err := time.Parse(time.RFC3339, v)
+	if err != nil {
+		panic(fmt.Sprintf("mustParseTime(%s): %s", v, err.Error()))
+	}
+	return &metav1.Time{Time: t}
 }

--- a/internal/saas/clusters_test.go
+++ b/internal/saas/clusters_test.go
@@ -219,8 +219,8 @@ func TestNewScanStatus(t *testing.T) {
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("NewScanStatus() mismatch (-want +got):\n%s", cmp.Diff(tt.want, got))
 			}
-			if pointer.IntDeref(totalIssues, 0) == pointer.IntDeref(tt.wantTotalIssues, 0) {
-				t.Errorf("NewScanStatus() totalIssues = %v, want %v", totalIssues, tt.wantTotalIssues)
+			if !reflect.DeepEqual(totalIssues, tt.wantTotalIssues) {
+				t.Errorf("NewScanStatus() totalIssues got = %v, want %v", totalIssues, tt.wantTotalIssues)
 			}
 		})
 	}


### PR DESCRIPTION
## Description
This PR fixes the sum of issues for misconfiguration scans.
A scan was being unnecessarily append into a slice with all scans. 
This slice always has the updated version of all scans.

## How has this been tested?
Configuring a misconfiguration scan and looking at `issueCount` field in ClusterScan status. It was always with the double.

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [ ] I have documented my code (if applicable)
- [ ] My changes are covered by tests
