### PR TITLE
Add persistence to trivy plugin for caching databases

### DIFF
--- a/charts/zora/README.md
+++ b/charts/zora/README.md
@@ -120,6 +120,10 @@ The following table lists the configurable parameters of the Zora chart and thei
 | scan.plugins.trivy.envFrom | list | `[]` | List of sources to populate environment variables in trivy container. |
 | scan.plugins.trivy.timeout | string | `"10m"` | Trivy timeout |
 | scan.plugins.trivy.insecure | bool | `false` | Allow insecure server connections for Trivy |
+| scan.plugins.trivy.persistence.enabled | bool | `true` | Specifies whether Trivy vulnerabilities database should be persisted between the scans, using PersistentVolumeClaim |
+| scan.plugins.trivy.persistence.accessMode | string | `"ReadWriteOnce"` | Persistence access mode |
+| scan.plugins.trivy.persistence.storageClass | string | `""` | Persistence storage class. Let it empty for default storage class. |
+| scan.plugins.trivy.persistence.storageRequest | string | `"1Gi"` | Persistence storage size |
 | scan.plugins.popeye.skipInternalResources | bool | `false` | Specifies whether the following resources should be skipped by `popeye` scans. 1. resources from `kube-system`, `kube-public` and `kube-node-lease` namespaces; 2. kubernetes system reserved RBAC (prefixed with `system:`); 3. `kube-root-ca.crt` configmaps; 4. `default` namespace; 5. `default` serviceaccounts; 6. Helm secrets (prefixed with `sh.helm.release`); 7. Zora components. See `popeye` configuration file that is used for this case: https://github.com/undistro/zora/blob/main/charts/zora/templates/plugins/popeye-config.yaml |
 | scan.plugins.popeye.resources | object | `{"limits":{"cpu":"500m","memory":"500Mi"},"requests":{"cpu":"250m","memory":"256Mi"}}` | [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) to add to `popeye` container |
 | scan.plugins.popeye.podAnnotations | object | `{}` | Annotations added to the popeye pods |

--- a/charts/zora/README.md
+++ b/charts/zora/README.md
@@ -122,8 +122,9 @@ The following table lists the configurable parameters of the Zora chart and thei
 | scan.plugins.trivy.insecure | bool | `false` | Allow insecure server connections for Trivy |
 | scan.plugins.trivy.persistence.enabled | bool | `true` | Specifies whether Trivy vulnerabilities database should be persisted between the scans, using PersistentVolumeClaim |
 | scan.plugins.trivy.persistence.accessMode | string | `"ReadWriteOnce"` | Persistence access mode |
-| scan.plugins.trivy.persistence.storageClass | string | `""` | Persistence storage class. Let it empty for default storage class. |
+| scan.plugins.trivy.persistence.storageClass | string | `""` | Persistence storage class. Let it empty for default storage class |
 | scan.plugins.trivy.persistence.storageRequest | string | `"1Gi"` | Persistence storage size |
+| scan.plugins.trivy.persistence.downloadJavaDB | bool | `false` | Specifies whether Java vulnerability database should be downloaded on helm install/upgrade |
 | scan.plugins.popeye.skipInternalResources | bool | `false` | Specifies whether the following resources should be skipped by `popeye` scans. 1. resources from `kube-system`, `kube-public` and `kube-node-lease` namespaces; 2. kubernetes system reserved RBAC (prefixed with `system:`); 3. `kube-root-ca.crt` configmaps; 4. `default` namespace; 5. `default` serviceaccounts; 6. Helm secrets (prefixed with `sh.helm.release`); 7. Zora components. See `popeye` configuration file that is used for this case: https://github.com/undistro/zora/blob/main/charts/zora/templates/plugins/popeye-config.yaml |
 | scan.plugins.popeye.resources | object | `{"limits":{"cpu":"500m","memory":"500Mi"},"requests":{"cpu":"250m","memory":"256Mi"}}` | [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) to add to `popeye` container |
 | scan.plugins.popeye.podAnnotations | object | `{}` | Annotations added to the popeye pods |

--- a/charts/zora/templates/operator/deployment.yaml
+++ b/charts/zora/templates/operator/deployment.yaml
@@ -81,6 +81,7 @@ spec:
             - --worker-image={{ printf "%s:%s" .Values.scan.worker.image.repository (.Values.scan.worker.image.tag | default .Chart.AppVersion) }}
             - --cronjob-clusterrolebinding-name=zora-plugins-rolebinding
             - --cronjob-serviceaccount-name=zora-plugins
+            - --trivy-db-pvc={{- if .Values.scan.plugins.trivy.persistence.enabled }}trivy-db{{- else }}""{{- end }}
 {{- if .Values.scan.plugins.annotations}}
             - --cronjob-serviceaccount-annotations={{ $first := true }}{{- range $key, $value := .Values.scan.plugins.annotations }}{{if not $first}},{{else}}{{$first = false}}{{end}}{{ $key }}={{$value}}{{- end }}
 {{- end }}

--- a/charts/zora/templates/plugins/trivy-job.yaml
+++ b/charts/zora/templates/plugins/trivy-job.yaml
@@ -38,7 +38,14 @@ spec:
           command:
             - /bin/sh
             - -c
-            - time trivy image --download-db-only --cache-dir=/tmp/trivy-cache --debug --no-progress {{ if .Values.scan.plugins.trivy.insecure }}--insecure{{- end }}
+            - time trivy image --download-db-only \
+                {{- if .Values.scan.plugins.trivy.persistence.downloadJavaDB }}
+                --download-java-db-only \
+                {{- end }}
+                {{- if .Values.scan.plugins.trivy.insecure }}
+                --insecure \
+                {{- end }}
+                --cache-dir=/tmp/trivy-cache --debug --no-progress
           env:
             - name: SSL_CERT_DIR
               value: "/etc/ssl/:/run/secrets/kubernetes.io/serviceaccount/"

--- a/charts/zora/templates/plugins/trivy-job.yaml
+++ b/charts/zora/templates/plugins/trivy-job.yaml
@@ -1,0 +1,52 @@
+# Copyright 2024 Undistro Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.scan.plugins.trivy.persistence.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: trivy-download-db
+spec:
+  ttlSecondsAfterFinished: 0
+  template:
+    spec:
+      volumes:
+        - name: trivy-db
+          persistentVolumeClaim:
+            claimName: trivy-db
+      containers:
+        - name: trivy-download-db
+          image: "{{ .Values.scan.plugins.trivy.image.repository }}:{{ .Values.scan.plugins.trivy.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+          volumeMounts:
+            - mountPath: /tmp/trivy-cache
+              name: trivy-db
+          command:
+            - /bin/sh
+            - -c
+            - time trivy image --download-db-only --cache-dir=/tmp/trivy-cache --debug --no-progress {{ if .Values.scan.plugins.trivy.insecure }}--insecure{{- end }}
+          env:
+            - name: SSL_CERT_DIR
+              value: "/etc/ssl/:/run/secrets/kubernetes.io/serviceaccount/"
+            {{- if .Values.httpsProxy }}
+            - name: HTTPS_PROXY
+              value: {{ .Values.httpsProxy | quote }}
+            - name: NO_PROXY
+              value: {{ .Values.noProxy | quote }}
+            {{- end }}
+      restartPolicy: OnFailure
+{{- end }}

--- a/charts/zora/templates/plugins/trivy-job.yaml
+++ b/charts/zora/templates/plugins/trivy-job.yaml
@@ -38,14 +38,18 @@ spec:
           command:
             - /bin/sh
             - -c
-            - time trivy image --download-db-only \
-                {{- if .Values.scan.plugins.trivy.persistence.downloadJavaDB }}
-                --download-java-db-only \
-                {{- end }}
+            - |
+              time trivy image \
+                --debug \
+                --no-progress \
+                --cache-dir=/tmp/trivy-cache \
                 {{- if .Values.scan.plugins.trivy.insecure }}
                 --insecure \
                 {{- end }}
-                --cache-dir=/tmp/trivy-cache --debug --no-progress
+                {{- if .Values.scan.plugins.trivy.persistence.downloadJavaDB }}
+                --download-java-db-only \
+                {{- end }}
+                --download-db-only
           env:
             - name: SSL_CERT_DIR
               value: "/etc/ssl/:/run/secrets/kubernetes.io/serviceaccount/"

--- a/charts/zora/templates/plugins/trivy-pvc.yaml
+++ b/charts/zora/templates/plugins/trivy-pvc.yaml
@@ -1,0 +1,29 @@
+# Copyright 2024 Undistro Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.scan.plugins.trivy.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: trivy-db
+spec:
+  {{- if .Values.scan.plugins.trivy.persistence.storageClass }}
+  storageClassName: {{ .Values.scan.plugins.trivy.persistence.storageClass | quote }}
+  {{- end }}
+  accessModes:
+    - {{ .Values.scan.plugins.trivy.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.scan.plugins.trivy.persistence.storageRequest | quote }}
+{{- end }}

--- a/charts/zora/templates/plugins/trivy.yaml
+++ b/charts/zora/templates/plugins/trivy.yaml
@@ -28,6 +28,7 @@ spec:
   mountCustomChecksVolume: false
   securityContext:
     allowPrivilegeEscalation: false
+    privileged: false
   {{- with .Values.scan.plugins.trivy.envFrom }}
   envFrom:
     {{- toYaml . | nindent 4}}

--- a/charts/zora/values.yaml
+++ b/charts/zora/values.yaml
@@ -229,6 +229,16 @@ scan:
       # -- Allow insecure server connections for Trivy
       insecure: false
 
+      persistence:
+        # -- Specifies whether Trivy vulnerabilities database should be persisted between the scans, using PersistentVolumeClaim
+        enabled: true
+        # -- Persistence access mode
+        accessMode: ReadWriteOnce
+        # -- Persistence storage class. Let it empty for default storage class.
+        storageClass: ""
+        # -- Persistence storage size
+        storageRequest: 1Gi
+
     popeye:
       # -- Specifies whether the following resources should be skipped by `popeye` scans.
       # 1. resources from `kube-system`, `kube-public` and `kube-node-lease` namespaces;

--- a/charts/zora/values.yaml
+++ b/charts/zora/values.yaml
@@ -234,10 +234,12 @@ scan:
         enabled: true
         # -- Persistence access mode
         accessMode: ReadWriteOnce
-        # -- Persistence storage class. Let it empty for default storage class.
+        # -- Persistence storage class. Let it empty for default storage class
         storageClass: ""
         # -- Persistence storage size
         storageRequest: 1Gi
+        # -- Specifies whether Java vulnerability database should be downloaded on helm install/upgrade
+        downloadJavaDB: false
 
     popeye:
       # -- Specifies whether the following resources should be skipped by `popeye` scans.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -68,6 +68,7 @@ func main() {
 	var checksConfigMapNamespace string
 	var checksConfigMapName string
 	var kubexnsImage string
+	var trivyPVC string
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -86,6 +87,7 @@ func main() {
 	flag.StringVar(&checksConfigMapNamespace, "checks-configmap-namespace", "zora-system", "Namespace of custom checks ConfigMap")
 	flag.StringVar(&checksConfigMapName, "checks-configmap-name", "zora-custom-checks", "Name of custom checks ConfigMap")
 	flag.StringVar(&kubexnsImage, "kubexns-image", "ghcr.io/undistro/kubexns:latest", "kubexns image")
+	flag.StringVar(&trivyPVC, "trivy-db-pvc", "", "PersistentVolumeClaim name for Trivy DB")
 
 	opts := zap.Options{
 		Development: true,
@@ -161,6 +163,7 @@ func main() {
 		OnUpdate:                onClusterScanUpdate,
 		OnDelete:                onClusterScanDelete,
 		KubexnsImage:            kubexnsImage,
+		TrivyPVC:                trivyPVC,
 		ChecksConfigMap:         fmt.Sprintf("%s/%s", checksConfigMapNamespace, checksConfigMapName),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ClusterScan")

--- a/internal/controller/zora/clusterscan_controller.go
+++ b/internal/controller/zora/clusterscan_controller.go
@@ -63,6 +63,7 @@ type ClusterScanReconciler struct {
 	ServiceAccountName      string
 	KubexnsImage            string
 	ChecksConfigMap         string
+	TrivyPVC                string
 	Annotations             map[string]string
 	OnUpdate                saas.ClusterScanHook
 	OnDelete                saas.ClusterScanHook
@@ -217,6 +218,7 @@ func (r *ClusterScanReconciler) reconcile(ctx context.Context, clusterscan *v1al
 			Suspend:            notReadyErr != nil,
 			KubexnsImage:       r.KubexnsImage,
 			ChecksConfigMap:    r.ChecksConfigMap,
+			TrivyPVC:           r.TrivyPVC,
 			ClusterUID:         cluster.UID,
 		}
 


### PR DESCRIPTION
## Description
This PR adds persistence to trivy plugin for caching vulnerability databases.

- When Zora Helm release is installed with default configuration, a PVC and a Job is created.
- The Job, which uses the PVC, downloads the vulnerability database.
- This Job is required when the persistence is enabled (true by default) so that PVC isn't  in `Pending` status (`WaitForFirstConsumer`)
- As a [best practice](https://loft.sh/blog/kubernetes-persistent-volumes-examples-and-best-practices/#best-practices), a PV is not created. Just a PVC. Then Kubernetes try to dynamically provision a volume specially for the PVC ([Dynamic Provisioning](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#dynamic))
- The Java vulnerability database is not downloaded by default (not every cluster has Java apps). But it can be downloaded by setting `scan.plugins.trivy.persistence.downloadJavaDB` to `true`
- The Job is deleted immediately after it finishes, due to `ttlSecondsAfterFinished: 0`
- The scheduled Trivy scans use the PVC as well, so the vulnerability databases is just downloaded when needed and no longer for every scan.

## How has this been tested?
- `kind create cluster`
- `make docker-build`
- `kind load docker-image controller:latest`
- `helm upgrade --install zora charts/zora/ -n zora-system --create-namespace --wait -f values.yaml` (content of `values.yaml` below)
- Check the Job logs: `kubectl logs job/trivy-download-db -n zora-system` then you should see a `Downloading DB...` entry
- Check the logs of the 1st Trivy scheduled scan: `kubectl logs kind-kind-vuln-trivy-28535863-tdlxz -n zora-system` then you should see a `DB update was skipped because the local DB is the latest` entry.

`values.yaml` content:
```yaml
clusterName: kind-kind
operator:
  image:
    repository: controller
    tag: latest
scan:
  plugins:
    trivy:
      persistence:
        enabled: true
```

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [ ] My changes are covered by tests
