### PR TITLE
bump marvin image version to 0.2.3

### DIFF
--- a/charts/zora/Chart.yaml
+++ b/charts/zora/Chart.yaml
@@ -17,7 +17,7 @@ name: zora
 description: A multi-plugin solution that reports misconfigurations and vulnerabilities by scanning your cluster at scheduled times.
 icon: https://zora-docs.undistro.io/v0.7/assets/logo.svg
 type: application
-version: 0.8.4-rc4
-appVersion: "v0.8.4-rc4"
+version: 0.8.4-rc6
+appVersion: "v0.8.4-rc6"
 sources:
   - https://github.com/undistro/zora

--- a/charts/zora/README.md
+++ b/charts/zora/README.md
@@ -107,7 +107,7 @@ The following table lists the configurable parameters of the Zora chart and thei
 | scan.plugins.marvin.resources | object | `{"limits":{"cpu":"500m","memory":"500Mi"},"requests":{"cpu":"250m","memory":"256Mi"}}` | [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) to add to `marvin` container |
 | scan.plugins.marvin.podAnnotations | object | `{}` | Annotations added to the marvin pods |
 | scan.plugins.marvin.image.repository | string | `"ghcr.io/undistro/marvin"` | marvin plugin image repository |
-| scan.plugins.marvin.image.tag | string | `"v0.2.1"` | marvin plugin image tag |
+| scan.plugins.marvin.image.tag | string | `"v0.2.3"` | marvin plugin image tag |
 | scan.plugins.marvin.env | list | `[]` | List of environment variables to set in marvin container. |
 | scan.plugins.marvin.envFrom | list | `[]` | List of sources to populate environment variables in marvin container. |
 | scan.plugins.trivy.ignoreUnfixed | bool | `false` | Specifies whether only fixed vulnerabilities should be reported |

--- a/charts/zora/README.md
+++ b/charts/zora/README.md
@@ -1,6 +1,6 @@
 # Zora Helm Chart
 
-![Version: 0.8.4-rc4](https://img.shields.io/badge/Version-0.8.4--rc4-informational?style=flat-square&color=3CA9DD) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square&color=3CA9DD) ![AppVersion: v0.8.4-rc4](https://img.shields.io/badge/AppVersion-v0.8.4--rc4-informational?style=flat-square&color=3CA9DD)
+![Version: 0.8.4-rc6](https://img.shields.io/badge/Version-0.8.4--rc6-informational?style=flat-square&color=3CA9DD) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square&color=3CA9DD) ![AppVersion: v0.8.4-rc6](https://img.shields.io/badge/AppVersion-v0.8.4--rc6-informational?style=flat-square&color=3CA9DD)
 
 A multi-plugin solution that reports misconfigurations and vulnerabilities by scanning your cluster at scheduled times.
 
@@ -13,7 +13,7 @@ helm repo add undistro https://charts.undistro.io --force-update
 helm repo update undistro
 helm upgrade --install zora undistro/zora \
   -n zora-system \
-  --version 0.8.4-rc4 \
+  --version 0.8.4-rc6 \
   --create-namespace \
   --wait \
   --set clusterName="$(kubectl config current-context)"

--- a/charts/zora/values.yaml
+++ b/charts/zora/values.yaml
@@ -190,7 +190,7 @@ scan:
         # -- marvin plugin image repository
         repository: ghcr.io/undistro/marvin
         # -- marvin plugin image tag
-        tag: v0.2.1
+        tag: v0.2.3
       # -- List of environment variables to set in marvin container.
       env: []
       # -- List of sources to populate environment variables in marvin container.


### PR DESCRIPTION
## Description
This PR bumps Marvin image version from 0.2.1 to 0.2.3.
I had only updated the version in go.mod and forgot to update the image in the last PR.

## Linked Issues
UD-1367

## How has this been tested?
- Creating a custom check which uses variables. Ex:
```yaml
apiVersion: zora.undistro.io/v1alpha2
kind: CustomCheck
metadata:
  name: custom-002
spec:
  message: "Required labels"
  severity: Low
  category: Custom
  match:
    resources:
      - group: ""
        version: v1
        resource: pods
  params:
    requiredLabels:
      - app
  variables:
    - expression: "'exempt' in object.metadata.labels && object.metadata.labels['exempt'] == 'true'"
      name: exempt
  validations:
    - expression: >
        variables.exempt ||
        !object.metadata.labels.all(label, 
          params.requiredLabels.all(
            req, req != label
          )
        )
      message: "Pod without required labels"
```

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [ ] My changes are covered by tests
