### PR TITLE
Do not set volume mount when Trivy persistence is disabled

### DIFF
--- a/charts/zora/Chart.yaml
+++ b/charts/zora/Chart.yaml
@@ -17,7 +17,7 @@ name: zora
 description: A multi-plugin solution that reports misconfigurations and vulnerabilities by scanning your cluster at scheduled times.
 icon: https://zora-docs.undistro.io/v0.7/assets/logo.svg
 type: application
-version: 0.8.4
-appVersion: "v0.8.4"
+version: 0.8.5-rc1
+appVersion: "v0.8.5-rc1"
 sources:
   - https://github.com/undistro/zora

--- a/charts/zora/README.md
+++ b/charts/zora/README.md
@@ -1,6 +1,6 @@
 # Zora Helm Chart
 
-![Version: 0.8.4](https://img.shields.io/badge/Version-0.8.4-informational?style=flat-square&color=3CA9DD) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square&color=3CA9DD) ![AppVersion: v0.8.4](https://img.shields.io/badge/AppVersion-v0.8.4-informational?style=flat-square&color=3CA9DD)
+![Version: 0.8.5-rc1](https://img.shields.io/badge/Version-0.8.5--rc1-informational?style=flat-square&color=3CA9DD) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square&color=3CA9DD) ![AppVersion: v0.8.5-rc1](https://img.shields.io/badge/AppVersion-v0.8.5--rc1-informational?style=flat-square&color=3CA9DD)
 
 A multi-plugin solution that reports misconfigurations and vulnerabilities by scanning your cluster at scheduled times.
 
@@ -13,7 +13,7 @@ helm repo add undistro https://charts.undistro.io --force-update
 helm repo update undistro
 helm upgrade --install zora undistro/zora \
   -n zora-system \
-  --version 0.8.4 \
+  --version 0.8.5-rc1 \
   --create-namespace \
   --wait \
   --set clusterName="$(kubectl config current-context)"

--- a/pkg/plugins/cronjob.go
+++ b/pkg/plugins/cronjob.go
@@ -237,7 +237,7 @@ func (r *CronJobMutator) pluginContainer() corev1.Container {
 	if pointer.BoolDeref(r.Plugin.Spec.MountCustomChecksVolume, false) {
 		c.VolumeMounts = append(c.VolumeMounts, customChecksVolume)
 	}
-	if r.Plugin.Name == "trivy" {
+	if r.Plugin.Name == "trivy" && r.TrivyPVC != "" {
 		c.VolumeMounts = append(c.VolumeMounts, trivyDBVolumeMount)
 	}
 	return c


### PR DESCRIPTION
## Description
This PR fixes the bug in ClusterScan reconciler when trivy persistence is disabled.

## Linked Issues
UD-1385

## How has this been tested?
- Installing Zora with trivy persistence disabled ([documentation](https://zora-docs.undistro.io/v0.8/configuration/vulnerability-database-persistence/))

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [ ] My changes are covered by tests
