### PR TITLE
fix empty flags when Trivy persistence is disabled

### DIFF
--- a/charts/zora/Chart.yaml
+++ b/charts/zora/Chart.yaml
@@ -17,7 +17,7 @@ name: zora
 description: A multi-plugin solution that reports misconfigurations and vulnerabilities by scanning your cluster at scheduled times.
 icon: https://zora-docs.undistro.io/v0.7/assets/logo.svg
 type: application
-version: 0.8.5-rc1
-appVersion: "v0.8.5-rc1"
+version: 0.8.5-rc2
+appVersion: "v0.8.5-rc2"
 sources:
   - https://github.com/undistro/zora

--- a/charts/zora/README.md
+++ b/charts/zora/README.md
@@ -1,6 +1,6 @@
 # Zora Helm Chart
 
-![Version: 0.8.5-rc1](https://img.shields.io/badge/Version-0.8.5--rc1-informational?style=flat-square&color=3CA9DD) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square&color=3CA9DD) ![AppVersion: v0.8.5-rc1](https://img.shields.io/badge/AppVersion-v0.8.5--rc1-informational?style=flat-square&color=3CA9DD)
+![Version: 0.8.5-rc2](https://img.shields.io/badge/Version-0.8.5--rc2-informational?style=flat-square&color=3CA9DD) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square&color=3CA9DD) ![AppVersion: v0.8.5-rc2](https://img.shields.io/badge/AppVersion-v0.8.5--rc2-informational?style=flat-square&color=3CA9DD)
 
 A multi-plugin solution that reports misconfigurations and vulnerabilities by scanning your cluster at scheduled times.
 
@@ -13,7 +13,7 @@ helm repo add undistro https://charts.undistro.io --force-update
 helm repo update undistro
 helm upgrade --install zora undistro/zora \
   -n zora-system \
-  --version 0.8.5-rc1 \
+  --version 0.8.5-rc2 \
   --create-namespace \
   --wait \
   --set clusterName="$(kubectl config current-context)"

--- a/charts/zora/templates/operator/deployment.yaml
+++ b/charts/zora/templates/operator/deployment.yaml
@@ -81,7 +81,7 @@ spec:
             - --worker-image={{ printf "%s:%s" .Values.scan.worker.image.repository (.Values.scan.worker.image.tag | default .Chart.AppVersion) }}
             - --cronjob-clusterrolebinding-name=zora-plugins-rolebinding
             - --cronjob-serviceaccount-name=zora-plugins
-            - --trivy-db-pvc={{- if .Values.scan.plugins.trivy.persistence.enabled }}trivy-db{{- else }}""{{- end }}
+            - --trivy-db-pvc={{- if .Values.scan.plugins.trivy.persistence.enabled }}trivy-db{{- end }}
 {{- if .Values.scan.plugins.annotations}}
             - --cronjob-serviceaccount-annotations={{ $first := true }}{{- range $key, $value := .Values.scan.plugins.annotations }}{{if not $first}},{{else}}{{$first = false}}{{end}}{{ $key }}={{$value}}{{- end }}
 {{- end }}


### PR DESCRIPTION
## Description
This PR fixes how the flag of Trivy persistence is passed to Operator when it is disabled.
A double quote was being passed instead of a empty string, causing the following error:
```
persistentvolumeclaim "\"\"" not found. preemption: 0/1 nodes are available: 1 No preemption victims found for incoming pod..
```

## Linked Issues
UD-1385

## How has this been tested?
- Installing zora with trivy persistence disabled

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [ ] My changes are covered by tests
