### PR TITLE
bump kubexns version from v0.1.3 to v0.1.4

### DIFF
--- a/charts/zora/README.md
+++ b/charts/zora/README.md
@@ -133,7 +133,7 @@ The following table lists the configurable parameters of the Zora chart and thei
 | scan.plugins.popeye.env | list | `[]` | List of environment variables to set in popeye container. |
 | scan.plugins.popeye.envFrom | list | `[]` | List of sources to populate environment variables in popeye container. |
 | kubexnsImage.repository | string | `"ghcr.io/undistro/kubexns"` | kubexns image repository |
-| kubexnsImage.tag | string | `"v0.1.3"` | kubexns image tag |
+| kubexnsImage.tag | string | `"v0.1.4"` | kubexns image tag |
 | customChecksConfigMap | string | `"zora-custom-checks"` | Custom checks ConfigMap name |
 | httpsProxy | string | `""` | HTTPS proxy URL |
 | noProxy | string | `"kubernetes.default.svc.*,127.0.0.1,localhost"` | Comma-separated list of URL patterns to be excluded from going through the proxy |

--- a/charts/zora/values.yaml
+++ b/charts/zora/values.yaml
@@ -276,7 +276,7 @@ kubexnsImage:
   # -- kubexns image repository
   repository: ghcr.io/undistro/kubexns
   # -- kubexns image tag
-  tag: v0.1.3
+  tag: v0.1.4
 
 # -- Custom checks ConfigMap name
 customChecksConfigMap: zora-custom-checks


### PR DESCRIPTION
## Description
This PR bumps kubexns version from v0.1.3 to v0.1.4

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [ ] My changes are covered by tests
