### PR TITLE
UD-1424: delay start of popeye plugin to allow other scans to start, …

### DIFF
--- a/charts/zora/templates/plugins/popeye.yaml
+++ b/charts/zora/templates/plugins/popeye.yaml
@@ -51,6 +51,7 @@ spec:
     - /bin/sh
     - -c
     - |
+      sleep 30
       start=$(date +%s)
       echo Scanning...
       {{- if .Values.scan.plugins.popeye.skipInternalResources }}


### PR DESCRIPTION
…preventing POP-203,POP-204,POP-207

## Description
Allow other plugin scans to start so we should not see POP-203, POP-204, POP-207 reported against them

## Linked Issues

## How has this been tested?
- Installing zora and checking for issues against plugin jobs

## Checklist
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [ ] I have documented my code (if applicable)
- [ ] My changes are covered by tests
