### PR TITLE
UD-1425: set the trivy security contest to run as non-root, preventin…

### DIFF
--- a/charts/zora/templates/plugins/trivy.yaml
+++ b/charts/zora/templates/plugins/trivy.yaml
@@ -27,6 +27,7 @@ spec:
   {{- end }}
   mountCustomChecksVolume: false
   securityContext:
+    runAsNonRoot: true
     allowPrivilegeEscalation: false
     privileged: false
   {{- with .Values.scan.plugins.trivy.envFrom }}


### PR DESCRIPTION
…g POP-302,POP-306

## Description
Updated security context to force runAsNonRoot.

Note a separate change was made to the patched Trivy image to add a non-root user and specify that at runtime, see the [modified Dockerfile](https://github.com/undistro/trivy/blob/undistro-v0.51.1-3/Dockerfile#L6-L7)

## Linked Issues

## How has this been tested?
- Install zora and check for POP-306,POP-302 issues logged against Trivy

## Checklist
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [ ] I have documented my code (if applicable)
- [ ] My changes are covered by tests
