### PR TITLE
UD-1423: Update charts to use the floating tags

### DIFF
--- a/charts/zora/README.md
+++ b/charts/zora/README.md
@@ -108,6 +108,7 @@ The following table lists the configurable parameters of the Zora chart and thei
 | scan.plugins.marvin.podAnnotations | object | `{}` | Annotations added to the marvin pods |
 | scan.plugins.marvin.image.repository | string | `"ghcr.io/undistro/marvin"` | marvin plugin image repository |
 | scan.plugins.marvin.image.tag | string | `"v0.2.3"` | marvin plugin image tag |
+| scan.plugins.marvin.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | scan.plugins.marvin.env | list | `[]` | List of environment variables to set in marvin container. |
 | scan.plugins.marvin.envFrom | list | `[]` | List of sources to populate environment variables in marvin container. |
 | scan.plugins.trivy.ignoreUnfixed | bool | `false` | Specifies whether only fixed vulnerabilities should be reported |
@@ -115,7 +116,8 @@ The following table lists the configurable parameters of the Zora chart and thei
 | scan.plugins.trivy.resources | object | `{}` | [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) to add to `trivy` container |
 | scan.plugins.trivy.podAnnotations | object | `{}` | Annotations added to the trivy pods |
 | scan.plugins.trivy.image.repository | string | `"ghcr.io/undistro/trivy"` | trivy plugin image repository |
-| scan.plugins.trivy.image.tag | string | `"0.50.1-1"` | trivy plugin image tag |
+| scan.plugins.trivy.image.tag | float | `0.51` | trivy plugin image tag |
+| scan.plugins.trivy.image.pullPolicy | string | `"Always"` | Image pull policy |
 | scan.plugins.trivy.env | list | `[]` | List of environment variables to set in trivy container. |
 | scan.plugins.trivy.envFrom | list | `[]` | List of sources to populate environment variables in trivy container. |
 | scan.plugins.trivy.timeout | string | `"10m"` | Trivy timeout |
@@ -129,7 +131,8 @@ The following table lists the configurable parameters of the Zora chart and thei
 | scan.plugins.popeye.resources | object | `{"limits":{"cpu":"500m","memory":"500Mi"},"requests":{"cpu":"250m","memory":"256Mi"}}` | [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) to add to `popeye` container |
 | scan.plugins.popeye.podAnnotations | object | `{}` | Annotations added to the popeye pods |
 | scan.plugins.popeye.image.repository | string | `"ghcr.io/undistro/popeye"` | popeye plugin image repository |
-| scan.plugins.popeye.image.tag | string | `"0.21.3-6"` | popeye plugin image tag |
+| scan.plugins.popeye.image.tag | float | `0.21` | popeye plugin image tag |
+| scan.plugins.popeye.image.pullPolicy | string | `"Always"` | Image pull policy |
 | scan.plugins.popeye.env | list | `[]` | List of environment variables to set in popeye container. |
 | scan.plugins.popeye.envFrom | list | `[]` | List of sources to populate environment variables in popeye container. |
 | kubexnsImage.repository | string | `"ghcr.io/undistro/kubexns"` | kubexns image repository |

--- a/charts/zora/templates/plugins/marvin.yaml
+++ b/charts/zora/templates/plugins/marvin.yaml
@@ -21,6 +21,9 @@ metadata:
 spec:
   type: misconfiguration
   image: "{{ .Values.scan.plugins.marvin.image.repository }}:{{ .Values.scan.plugins.marvin.image.tag }}"
+  {{- if .Values.scan.plugins.marvin.image.pullPolicy }}
+  imagePullPolicy: "{{ .Values.scan.plugins.marvin.image.pullPolicy }}"
+  {{- end }}
   {{- if .Values.scan.plugins.marvin.resources }}
   resources:
     {{- toYaml .Values.scan.plugins.marvin.resources | nindent 4 }}

--- a/charts/zora/templates/plugins/popeye.yaml
+++ b/charts/zora/templates/plugins/popeye.yaml
@@ -21,6 +21,9 @@ metadata:
 spec:
   type: misconfiguration
   image: "{{ .Values.scan.plugins.popeye.image.repository }}:{{ .Values.scan.plugins.popeye.image.tag }}"
+  {{- if .Values.scan.plugins.popeye.image.pullPolicy }}
+  imagePullPolicy: "{{ .Values.scan.plugins.popeye.image.pullPolicy }}"
+  {{- end }}
   {{- if .Values.scan.plugins.popeye.resources }}
   resources:
     {{- toYaml .Values.scan.plugins.popeye.resources | nindent 4 }}

--- a/charts/zora/templates/plugins/trivy.yaml
+++ b/charts/zora/templates/plugins/trivy.yaml
@@ -21,6 +21,9 @@ metadata:
 spec:
   type: vulnerability
   image: "{{ .Values.scan.plugins.trivy.image.repository }}:{{ .Values.scan.plugins.trivy.image.tag }}"
+  {{- if .Values.scan.plugins.trivy.image.pullPolicy }}
+  imagePullPolicy: "{{ .Values.scan.plugins.trivy.image.pullPolicy }}"
+  {{- end }}
   {{- if .Values.scan.plugins.trivy.resources }}
   resources:
     {{- toYaml .Values.scan.plugins.trivy.resources | nindent 4 }}
@@ -58,7 +61,6 @@ spec:
       time trivy k8s \
         --debug \
         --no-progress \
-        --all-namespaces \
         --scanners=vuln \
         -f=json \
         --cache-dir=/tmp/trivy-cache \
@@ -69,8 +71,7 @@ spec:
         --ignore-unfixed \
         {{- end }}
         --timeout={{ .Values.scan.plugins.trivy.timeout | quote }} \
-        -o $(DONE_DIR)/results.json \
-        cluster
+        -o $(DONE_DIR)/results.json
 
       exitcode=$(echo $?)
       if [ $exitcode -ne 0 ]; then

--- a/charts/zora/values.yaml
+++ b/charts/zora/values.yaml
@@ -191,6 +191,8 @@ scan:
         repository: ghcr.io/undistro/marvin
         # -- marvin plugin image tag
         tag: v0.2.3
+        # -- Image pull policy
+        pullPolicy: IfNotPresent
       # -- List of environment variables to set in marvin container.
       env: []
       # -- List of sources to populate environment variables in marvin container.
@@ -209,7 +211,9 @@ scan:
         # -- trivy plugin image repository
         repository: ghcr.io/undistro/trivy
         # -- trivy plugin image tag
-        tag: 0.50.1-1
+        tag: 0.51
+        # -- Image pull policy
+        pullPolicy: Always
       # -- List of environment variables to set in trivy container.
       env: []
       #  - name: AWS_REGION
@@ -266,7 +270,9 @@ scan:
         # -- popeye plugin image repository
         repository: ghcr.io/undistro/popeye
         # -- popeye plugin image tag
-        tag: 0.21.3-6
+        tag: 0.21
+        # -- Image pull policy
+        pullPolicy: Always
       # -- List of environment variables to set in popeye container.
       env: []
       # -- List of sources to populate environment variables in popeye container.


### PR DESCRIPTION
## Description
Update the plugin charts to use the floating tags, set the default image pull policy to Always so it checks for the latest image

## Linked Issues

## How has this been tested?
- Install zora and verify the floating tags are being used in the CronJobs for trivy and popeye, also verify their pull policy is set to Always
- Install zora with pull policies for trivy and popeye commented out in values.yaml, check CronJob configuration to verify pull policy is set to IfNotPresent

## Checklist
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [ ] I have documented my code (if applicable)
- [ ] My changes are covered by tests
