### PR TITLE
Use certificates from existing secret if it already exists

### DIFF
--- a/charts/zora/templates/operator/deployment.yaml
+++ b/charts/zora/templates/operator/deployment.yaml
@@ -13,20 +13,25 @@
 # limitations under the License.
 {{ $secretName := printf "%s-serving-cert" (include "zora.fullname" .) -}}
 {{- $serviceName := printf "%s-webhook" (include "zora.fullname" .) -}}
-{{- if and .Values.operator.webhook.enabled (not (lookup "v1" "Secret" .Release.Namespace $secretName)) -}}
-  {{- $cn := $serviceName -}}
-  {{- $ca := genCA $cn 3650 -}}
-  {{- $altNames := list ( printf "%s.%s" $serviceName .Release.Namespace ) ( printf "%s.%s.svc" $serviceName .Release.Namespace ) ( printf "%s.%s.svc.cluster.local" $serviceName .Release.Namespace ) -}}
-  {{- $cert := genSignedCert $cn nil $altNames 3650 $ca -}}
+{{- if .Values.operator.webhook.enabled -}}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $secretName -}}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $secretName }}
 type: kubernetes.io/tls
 data:
+{{- if $existingSecret }}
+  {{- toYaml $existingSecret.data | nindent 2 }}
+{{- else }}
+  {{- $cn := $serviceName }}
+  {{- $ca := genCA $cn 3650 }}
+  {{- $altNames := list ( printf "%s.%s" $serviceName .Release.Namespace ) ( printf "%s.%s.svc" $serviceName .Release.Namespace ) ( printf "%s.%s.svc.cluster.local" $serviceName .Release.Namespace ) }}
+  {{- $cert := genSignedCert $cn nil $altNames 3650 $ca }}
   tls.key: {{ b64enc $cert.Key }}
   tls.crt: {{ b64enc $cert.Cert }}
   ca.crt: {{ b64enc $ca.Cert }}
+{{- end }}
 ---
 {{- end -}}
 apiVersion: apps/v1


### PR DESCRIPTION
## Description
This PR fixes a bug of deleting the secret on upgrades.

## Linked Issues
UD-1437

## How has this been tested?
Installing Zora Helm chart, upgrading it, and checking the secret `zora-serving-cert`.

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [ ] My changes are covered by tests
