### PR TITLE
Add fields `totalPackages` and `totalUniquePackages` in VulnerabilityReport

### DIFF
--- a/api/zora/v1alpha2/vulnerabilityreport_conversion_test.go
+++ b/api/zora/v1alpha2/vulnerabilityreport_conversion_test.go
@@ -76,6 +76,8 @@ func TestVulnerabilityReportConversion(t *testing.T) {
 				ObjectMeta: meta,
 				Spec: VulnerabilityReportSpec{
 					VulnerabilityReportCommon: newVulnerabilityReportCommon(v1alpha1.VulnerabilitySummary{Total: 1, High: 1}),
+					TotalPackages:             2,
+					TotalUniquePackages:       2,
 					Vulnerabilities: []Vulnerability{{
 						VulnerabilityCommon: vulnCommon,
 						Packages: []v1alpha1.Package{

--- a/api/zora/v1alpha2/vulnerabilityreport_types.go
+++ b/api/zora/v1alpha2/vulnerabilityreport_types.go
@@ -22,10 +22,21 @@ import (
 // VulnerabilityReportSpec defines the desired state of VulnerabilityReport
 type VulnerabilityReportSpec struct {
 	v1alpha1.VulnerabilityReportCommon `json:",inline"`
-	Vulnerabilities                    []Vulnerability `json:"vulnerabilities"`
+
+	// TotalPackages represents the total number of affected packages in this image.
+	// A package affected by two vulnerabilities is counted twice.
+	TotalPackages int `json:"totalPackages"`
+
+	// TotalUniquePackages represents the total number of unique affected packages in this image.
+	// A package affected by multiple vulnerabilities is counted only once.
+	TotalUniquePackages int `json:"totalUniquePackages"`
+
+	Vulnerabilities []Vulnerability `json:"vulnerabilities"`
 }
 
 func (in *VulnerabilityReportSpec) Summarize() {
+	total := 0
+	unique := make(map[string]bool)
 	s := &v1alpha1.VulnerabilitySummary{}
 	for _, v := range in.Vulnerabilities {
 		s.Total++
@@ -41,8 +52,14 @@ func (in *VulnerabilityReportSpec) Summarize() {
 		default:
 			s.Unknown++
 		}
+		for _, p := range v.Packages {
+			total++
+			unique[p.String()] = true
+		}
 	}
 	in.Summary = *s
+	in.TotalPackages = total
+	in.TotalUniquePackages = len(unique)
 }
 
 type Vulnerability struct {

--- a/charts/zora/Chart.yaml
+++ b/charts/zora/Chart.yaml
@@ -17,7 +17,7 @@ name: zora
 description: A multi-plugin solution that reports misconfigurations and vulnerabilities by scanning your cluster at scheduled times.
 icon: https://zora-docs.undistro.io/v0.7/assets/logo.svg
 type: application
-version: 0.8.5-rc3
-appVersion: "v0.8.5-rc3"
+version: 0.8.5-rc4
+appVersion: "v0.8.5-rc4"
 sources:
   - https://github.com/undistro/zora

--- a/charts/zora/README.md
+++ b/charts/zora/README.md
@@ -1,6 +1,6 @@
 # Zora Helm Chart
 
-![Version: 0.8.5-rc3](https://img.shields.io/badge/Version-0.8.5--rc3-informational?style=flat-square&color=3CA9DD) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square&color=3CA9DD) ![AppVersion: v0.8.5-rc3](https://img.shields.io/badge/AppVersion-v0.8.5--rc3-informational?style=flat-square&color=3CA9DD)
+![Version: 0.8.5-rc4](https://img.shields.io/badge/Version-0.8.5--rc4-informational?style=flat-square&color=3CA9DD) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square&color=3CA9DD) ![AppVersion: v0.8.5-rc4](https://img.shields.io/badge/AppVersion-v0.8.5--rc4-informational?style=flat-square&color=3CA9DD)
 
 A multi-plugin solution that reports misconfigurations and vulnerabilities by scanning your cluster at scheduled times.
 
@@ -13,7 +13,7 @@ helm repo add undistro https://charts.undistro.io --force-update
 helm repo update undistro
 helm upgrade --install zora undistro/zora \
   -n zora-system \
-  --version 0.8.5-rc3 \
+  --version 0.8.5-rc4 \
   --create-namespace \
   --wait \
   --set clusterName="$(kubectl config current-context)"

--- a/charts/zora/crds/zora.undistro.io_vulnerabilityreports.yaml
+++ b/charts/zora/crds/zora.undistro.io_vulnerabilityreports.yaml
@@ -371,7 +371,17 @@ spec:
                   items:
                     type: string
                   type: array
+                totalPackages:
+                  description: |-
+                    TotalPackages represents the total number of affected packages in this image.
+                    A package affected by two vulnerabilities is counted twice.
+                  type: integer
                 totalResources:
+                  type: integer
+                totalUniquePackages:
+                  description: |-
+                    TotalUniquePackages represents the total number of unique affected packages in this image.
+                    A package affected by multiple vulnerabilities is counted only once.
                   type: integer
                 vulnerabilities:
                   items:
@@ -425,7 +435,9 @@ spec:
                 - image
                 - resources
                 - summary
+                - totalPackages
                 - totalResources
+                - totalUniquePackages
                 - vulnerabilities
               type: object
             status:

--- a/config/crd/bases/zora.undistro.io_vulnerabilityreports.yaml
+++ b/config/crd/bases/zora.undistro.io_vulnerabilityreports.yaml
@@ -357,7 +357,17 @@ spec:
                   items:
                     type: string
                   type: array
+                totalPackages:
+                  description: |-
+                    TotalPackages represents the total number of affected packages in this image.
+                    A package affected by two vulnerabilities is counted twice.
+                  type: integer
                 totalResources:
+                  type: integer
+                totalUniquePackages:
+                  description: |-
+                    TotalUniquePackages represents the total number of unique affected packages in this image.
+                    A package affected by multiple vulnerabilities is counted only once.
                   type: integer
                 vulnerabilities:
                   items:
@@ -411,7 +421,9 @@ spec:
                 - image
                 - resources
                 - summary
+                - totalPackages
                 - totalResources
+                - totalUniquePackages
                 - vulnerabilities
               type: object
             status:

--- a/pkg/worker/report/trivy/parse_test.go
+++ b/pkg/worker/report/trivy/parse_test.go
@@ -54,6 +54,8 @@ func TestParse(t *testing.T) {
 						Resources:      map[string][]string{"Pod": {"kube-system/kube-apiserver-kind-control-plane"}},
 						Summary:        v1alpha1.VulnerabilitySummary{Total: 1, High: 1},
 					},
+					TotalPackages:       1,
+					TotalUniquePackages: 1,
 					Vulnerabilities: []v1alpha2.Vulnerability{
 						{
 							Packages: []v1alpha1.Package{{
@@ -86,8 +88,10 @@ func TestParse(t *testing.T) {
 						Distro:         &v1alpha1.Distro{Name: "alpine", Version: "3.16.3"},
 						TotalResources: 2,
 						Resources:      map[string][]string{"Deployment": {"apps/app1", "apps/app2"}},
-						Summary:        v1alpha1.VulnerabilitySummary{Total: 2, Critical: 1, High: 1},
+						Summary:        v1alpha1.VulnerabilitySummary{Total: 3, Critical: 1, High: 2},
 					},
+					TotalPackages:       4,
+					TotalUniquePackages: 3,
 					Vulnerabilities: []v1alpha2.Vulnerability{
 						{
 							Packages: []v1alpha1.Package{
@@ -136,6 +140,27 @@ func TestParse(t *testing.T) {
 								LastModifiedDate: newTime("2023-08-12T06:16:00Z"),
 							},
 						},
+						{
+							Packages: []v1alpha1.Package{
+								{
+									Package:    "libssl1.1",
+									Version:    "1.1.1s-r0",
+									FixVersion: "1.1.1t-r0",
+									Status:     "fixed",
+									Type:       "alpine",
+								},
+							},
+							VulnerabilityCommon: v1alpha1.VulnerabilityCommon{
+								ID:               "CVE-2023-0286",
+								Severity:         "HIGH",
+								Title:            "openssl: X.400 address type confusion in X.509 GeneralName",
+								Description:      "There is a type confusion vulnerability relating to X.400 address processing\ninside an X.509 GeneralName. X.400 addresses were parsed as an ASN1_STRING but\nthe public structure definition for GENERAL_NAME incorrectly specified the type\nof the x400Address field as ASN1_TYPE. This field is subsequently interpreted by\nthe OpenSSL function GENERAL_NAME_cmp as an ASN1_TYPE rather than an\nASN1_STRING.\n\nWhen CRL checking is enabled (i.e. the application sets the\nX509_V_FLAG_CRL_CHECK flag), this vulnerability may allow an attacker to pass\narbitrary pointers to a memcmp call, enabling them to read memory contents or\nenact a denial of service. In most cases, the attack requires the attacker to\nprovide both the certificate chain and CRL, neither of which need to have a\nvalid signature. If the attacker only controls one of these inputs, the other\ninput must already contain an X.400 address as a CRL distribution point, which\nis uncommon. As such, this vulnerability is most likely to only affect\napplications which have implemented their own functionality for retrieving CRLs\nover a network.\n\n",
+								URL:              "https://avd.aquasec.com/nvd/cve-2023-0286",
+								Score:            "7.4",
+								PublishedDate:    newTime("2023-02-08T20:15:24.267Z"),
+								LastModifiedDate: newTime("2024-02-04T09:15:09.113Z"),
+							},
+						},
 					},
 				},
 				{
@@ -150,6 +175,8 @@ func TestParse(t *testing.T) {
 						Resources:      map[string][]string{"Deployment": {"apps/app1"}},
 						Summary:        v1alpha1.VulnerabilitySummary{Total: 3, High: 1, Medium: 1, Unknown: 1},
 					},
+					TotalPackages:       3,
+					TotalUniquePackages: 3,
 					Vulnerabilities: []v1alpha2.Vulnerability{
 						{
 							Packages: []v1alpha1.Package{{
@@ -222,6 +249,8 @@ func TestParse(t *testing.T) {
 						Resources:      map[string][]string{"Deployment": {"apps/app2"}},
 						Summary:        v1alpha1.VulnerabilitySummary{Total: 2, High: 1, Low: 1},
 					},
+					TotalPackages:       2,
+					TotalUniquePackages: 2,
 					Vulnerabilities: []v1alpha2.Vulnerability{
 						{
 							Packages: []v1alpha1.Package{{
@@ -275,6 +304,8 @@ func TestParse(t *testing.T) {
 						Resources:      map[string][]string{"Deployment": {"default/nginx"}},
 						Summary:        v1alpha1.VulnerabilitySummary{Total: 1, Medium: 1},
 					},
+					TotalPackages:       1,
+					TotalUniquePackages: 1,
 					Vulnerabilities: []v1alpha2.Vulnerability{
 						{
 							Packages: []v1alpha1.Package{{

--- a/pkg/worker/report/trivy/testdata/report.json
+++ b/pkg/worker/report/trivy/testdata/report.json
@@ -964,6 +964,119 @@
               ],
               "PublishedDate": "2023-02-08T20:15:00Z",
               "LastModifiedDate": "2023-07-19T00:57:00Z"
+            },
+            {
+              "VulnerabilityID": "CVE-2023-0286",
+              "PkgID": "libssl1.1@1.1.1s-r0",
+              "PkgName": "libssl1.1",
+              "PkgIdentifier": {
+                "PURL": "pkg:apk/alpine/libssl1.1@1.1.1s-r0?arch=x86_64\u0026distro=3.16.3"
+              },
+              "InstalledVersion": "1.1.1s-r0",
+              "FixedVersion": "1.1.1t-r0",
+              "Status": "fixed",
+              "Layer": {
+                "Digest": "sha256:ca7dd9ec2225f2385955c43b2379305acd51543c28cf1d4e94522b3d94cce3ce",
+                "DiffID": "sha256:e5e13b0c77cbb769548077189c3da2f0a764ceca06af49d8d558e759f5c232bd"
+              },
+              "SeveritySource": "nvd",
+              "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2023-0286",
+              "DataSource": {
+                "ID": "alpine",
+                "Name": "Alpine Secdb",
+                "URL": "https://secdb.alpinelinux.org/"
+              },
+              "Title": "openssl: X.400 address type confusion in X.509 GeneralName",
+              "Description": "There is a type confusion vulnerability relating to X.400 address processing\ninside an X.509 GeneralName. X.400 addresses were parsed as an ASN1_STRING but\nthe public structure definition for GENERAL_NAME incorrectly specified the type\nof the x400Address field as ASN1_TYPE. This field is subsequently interpreted by\nthe OpenSSL function GENERAL_NAME_cmp as an ASN1_TYPE rather than an\nASN1_STRING.\n\nWhen CRL checking is enabled (i.e. the application sets the\nX509_V_FLAG_CRL_CHECK flag), this vulnerability may allow an attacker to pass\narbitrary pointers to a memcmp call, enabling them to read memory contents or\nenact a denial of service. In most cases, the attack requires the attacker to\nprovide both the certificate chain and CRL, neither of which need to have a\nvalid signature. If the attacker only controls one of these inputs, the other\ninput must already contain an X.400 address as a CRL distribution point, which\nis uncommon. As such, this vulnerability is most likely to only affect\napplications which have implemented their own functionality for retrieving CRLs\nover a network.\n\n",
+              "Severity": "HIGH",
+              "CweIDs": [
+                "CWE-843"
+              ],
+              "VendorSeverity": {
+                "alma": 3,
+                "amazon": 3,
+                "cbl-mariner": 3,
+                "ghsa": 3,
+                "nvd": 3,
+                "oracle-oval": 3,
+                "photon": 3,
+                "redhat": 3,
+                "rocky": 3,
+                "ubuntu": 3
+              },
+              "CVSS": {
+                "ghsa": {
+                  "V3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:H",
+                  "V3Score": 7.4
+                },
+                "nvd": {
+                  "V3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:H",
+                  "V3Score": 7.4
+                },
+                "redhat": {
+                  "V3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:H",
+                  "V3Score": 7.4
+                }
+              },
+              "References": [
+                "https://access.redhat.com/errata/RHSA-2023:2165",
+                "https://access.redhat.com/security/cve/CVE-2023-0286",
+                "https://access.redhat.com/security/cve/cve-2023-0286",
+                "https://bugzilla.redhat.com/1960321",
+                "https://bugzilla.redhat.com/2164440",
+                "https://bugzilla.redhat.com/2164487",
+                "https://bugzilla.redhat.com/2164492",
+                "https://bugzilla.redhat.com/2164494",
+                "https://bugzilla.redhat.com/show_bug.cgi?id=2144000",
+                "https://bugzilla.redhat.com/show_bug.cgi?id=2144003",
+                "https://bugzilla.redhat.com/show_bug.cgi?id=2144006",
+                "https://bugzilla.redhat.com/show_bug.cgi?id=2144008",
+                "https://bugzilla.redhat.com/show_bug.cgi?id=2144010",
+                "https://bugzilla.redhat.com/show_bug.cgi?id=2144012",
+                "https://bugzilla.redhat.com/show_bug.cgi?id=2144015",
+                "https://bugzilla.redhat.com/show_bug.cgi?id=2144017",
+                "https://bugzilla.redhat.com/show_bug.cgi?id=2144019",
+                "https://bugzilla.redhat.com/show_bug.cgi?id=2145170",
+                "https://bugzilla.redhat.com/show_bug.cgi?id=2158412",
+                "https://bugzilla.redhat.com/show_bug.cgi?id=2164440",
+                "https://bugzilla.redhat.com/show_bug.cgi?id=2164487",
+                "https://bugzilla.redhat.com/show_bug.cgi?id=2164488",
+                "https://bugzilla.redhat.com/show_bug.cgi?id=2164492",
+                "https://bugzilla.redhat.com/show_bug.cgi?id=2164494",
+                "https://bugzilla.redhat.com/show_bug.cgi?id=2164497",
+                "https://bugzilla.redhat.com/show_bug.cgi?id=2164499",
+                "https://bugzilla.redhat.com/show_bug.cgi?id=2164500",
+                "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-4203",
+                "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-4304",
+                "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-4450",
+                "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-0215",
+                "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-0216",
+                "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-0217",
+                "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-0286",
+                "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-0401",
+                "https://errata.almalinux.org/9/ALSA-2023-2165.html",
+                "https://errata.rockylinux.org/RLSA-2023:0946",
+                "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.6.2-relnotes.txt",
+                "https://ftp.openbsd.org/pub/OpenBSD/patches/7.2/common/018_x509.patch.sig",
+                "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=2c6c9d439b484e1ba9830d8454a34fa4f80fdfe9",
+                "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=2f7530077e0ef79d98718138716bc51ca0cad658",
+                "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=fd2af07dc083a350c959147097003a14a5e8ac4d",
+                "https://github.com/pyca/cryptography",
+                "https://github.com/pyca/cryptography/security/advisories/GHSA-x4qr-2fvf-3mr5",
+                "https://linux.oracle.com/cve/CVE-2023-0286.html",
+                "https://linux.oracle.com/errata/ELSA-2023-32791.html",
+                "https://nvd.nist.gov/vuln/detail/CVE-2023-0286",
+                "https://rustsec.org/advisories/RUSTSEC-2023-0006.html",
+                "https://security.gentoo.org/glsa/202402-08",
+                "https://ubuntu.com/security/notices/USN-5844-1",
+                "https://ubuntu.com/security/notices/USN-5845-1",
+                "https://ubuntu.com/security/notices/USN-5845-2",
+                "https://ubuntu.com/security/notices/USN-6564-1",
+                "https://www.cve.org/CVERecord?id=CVE-2023-0286",
+                "https://www.openssl.org/news/secadv/20230207.txt"
+              ],
+              "PublishedDate": "2023-02-08T20:15:24.267Z",
+              "LastModifiedDate": "2024-02-04T09:15:09.113Z"
             }
           ]
         },
@@ -1389,6 +1502,119 @@
               ],
               "PublishedDate": "2023-02-08T20:15:00Z",
               "LastModifiedDate": "2023-07-19T00:57:00Z"
+            },
+            {
+              "VulnerabilityID": "CVE-2023-0286",
+              "PkgID": "libssl1.1@1.1.1s-r0",
+              "PkgName": "libssl1.1",
+              "PkgIdentifier": {
+                "PURL": "pkg:apk/alpine/libssl1.1@1.1.1s-r0?arch=x86_64\u0026distro=3.16.3"
+              },
+              "InstalledVersion": "1.1.1s-r0",
+              "FixedVersion": "1.1.1t-r0",
+              "Status": "fixed",
+              "Layer": {
+                "Digest": "sha256:ca7dd9ec2225f2385955c43b2379305acd51543c28cf1d4e94522b3d94cce3ce",
+                "DiffID": "sha256:e5e13b0c77cbb769548077189c3da2f0a764ceca06af49d8d558e759f5c232bd"
+              },
+              "SeveritySource": "nvd",
+              "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2023-0286",
+              "DataSource": {
+                "ID": "alpine",
+                "Name": "Alpine Secdb",
+                "URL": "https://secdb.alpinelinux.org/"
+              },
+              "Title": "openssl: X.400 address type confusion in X.509 GeneralName",
+              "Description": "There is a type confusion vulnerability relating to X.400 address processing\ninside an X.509 GeneralName. X.400 addresses were parsed as an ASN1_STRING but\nthe public structure definition for GENERAL_NAME incorrectly specified the type\nof the x400Address field as ASN1_TYPE. This field is subsequently interpreted by\nthe OpenSSL function GENERAL_NAME_cmp as an ASN1_TYPE rather than an\nASN1_STRING.\n\nWhen CRL checking is enabled (i.e. the application sets the\nX509_V_FLAG_CRL_CHECK flag), this vulnerability may allow an attacker to pass\narbitrary pointers to a memcmp call, enabling them to read memory contents or\nenact a denial of service. In most cases, the attack requires the attacker to\nprovide both the certificate chain and CRL, neither of which need to have a\nvalid signature. If the attacker only controls one of these inputs, the other\ninput must already contain an X.400 address as a CRL distribution point, which\nis uncommon. As such, this vulnerability is most likely to only affect\napplications which have implemented their own functionality for retrieving CRLs\nover a network.\n\n",
+              "Severity": "HIGH",
+              "CweIDs": [
+                "CWE-843"
+              ],
+              "VendorSeverity": {
+                "alma": 3,
+                "amazon": 3,
+                "cbl-mariner": 3,
+                "ghsa": 3,
+                "nvd": 3,
+                "oracle-oval": 3,
+                "photon": 3,
+                "redhat": 3,
+                "rocky": 3,
+                "ubuntu": 3
+              },
+              "CVSS": {
+                "ghsa": {
+                  "V3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:H",
+                  "V3Score": 7.4
+                },
+                "nvd": {
+                  "V3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:H",
+                  "V3Score": 7.4
+                },
+                "redhat": {
+                  "V3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:H",
+                  "V3Score": 7.4
+                }
+              },
+              "References": [
+                "https://access.redhat.com/errata/RHSA-2023:2165",
+                "https://access.redhat.com/security/cve/CVE-2023-0286",
+                "https://access.redhat.com/security/cve/cve-2023-0286",
+                "https://bugzilla.redhat.com/1960321",
+                "https://bugzilla.redhat.com/2164440",
+                "https://bugzilla.redhat.com/2164487",
+                "https://bugzilla.redhat.com/2164492",
+                "https://bugzilla.redhat.com/2164494",
+                "https://bugzilla.redhat.com/show_bug.cgi?id=2144000",
+                "https://bugzilla.redhat.com/show_bug.cgi?id=2144003",
+                "https://bugzilla.redhat.com/show_bug.cgi?id=2144006",
+                "https://bugzilla.redhat.com/show_bug.cgi?id=2144008",
+                "https://bugzilla.redhat.com/show_bug.cgi?id=2144010",
+                "https://bugzilla.redhat.com/show_bug.cgi?id=2144012",
+                "https://bugzilla.redhat.com/show_bug.cgi?id=2144015",
+                "https://bugzilla.redhat.com/show_bug.cgi?id=2144017",
+                "https://bugzilla.redhat.com/show_bug.cgi?id=2144019",
+                "https://bugzilla.redhat.com/show_bug.cgi?id=2145170",
+                "https://bugzilla.redhat.com/show_bug.cgi?id=2158412",
+                "https://bugzilla.redhat.com/show_bug.cgi?id=2164440",
+                "https://bugzilla.redhat.com/show_bug.cgi?id=2164487",
+                "https://bugzilla.redhat.com/show_bug.cgi?id=2164488",
+                "https://bugzilla.redhat.com/show_bug.cgi?id=2164492",
+                "https://bugzilla.redhat.com/show_bug.cgi?id=2164494",
+                "https://bugzilla.redhat.com/show_bug.cgi?id=2164497",
+                "https://bugzilla.redhat.com/show_bug.cgi?id=2164499",
+                "https://bugzilla.redhat.com/show_bug.cgi?id=2164500",
+                "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-4203",
+                "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-4304",
+                "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-4450",
+                "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-0215",
+                "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-0216",
+                "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-0217",
+                "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-0286",
+                "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-0401",
+                "https://errata.almalinux.org/9/ALSA-2023-2165.html",
+                "https://errata.rockylinux.org/RLSA-2023:0946",
+                "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.6.2-relnotes.txt",
+                "https://ftp.openbsd.org/pub/OpenBSD/patches/7.2/common/018_x509.patch.sig",
+                "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=2c6c9d439b484e1ba9830d8454a34fa4f80fdfe9",
+                "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=2f7530077e0ef79d98718138716bc51ca0cad658",
+                "https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=fd2af07dc083a350c959147097003a14a5e8ac4d",
+                "https://github.com/pyca/cryptography",
+                "https://github.com/pyca/cryptography/security/advisories/GHSA-x4qr-2fvf-3mr5",
+                "https://linux.oracle.com/cve/CVE-2023-0286.html",
+                "https://linux.oracle.com/errata/ELSA-2023-32791.html",
+                "https://nvd.nist.gov/vuln/detail/CVE-2023-0286",
+                "https://rustsec.org/advisories/RUSTSEC-2023-0006.html",
+                "https://security.gentoo.org/glsa/202402-08",
+                "https://ubuntu.com/security/notices/USN-5844-1",
+                "https://ubuntu.com/security/notices/USN-5845-1",
+                "https://ubuntu.com/security/notices/USN-5845-2",
+                "https://ubuntu.com/security/notices/USN-6564-1",
+                "https://www.cve.org/CVERecord?id=CVE-2023-0286",
+                "https://www.openssl.org/news/secadv/20230207.txt"
+              ],
+              "PublishedDate": "2023-02-08T20:15:24.267Z",
+              "LastModifiedDate": "2024-02-04T09:15:09.113Z"
             }
           ]
         },

--- a/pkg/worker/vuln_test.go
+++ b/pkg/worker/vuln_test.go
@@ -112,6 +112,8 @@ func TestParseVulnResults(t *testing.T) {
 							TotalResources: 1,
 							Summary:        v1alpha1.VulnerabilitySummary{Total: 1, High: 1},
 						},
+						TotalPackages:       1,
+						TotalUniquePackages: 1,
 						Vulnerabilities: []v1alpha2.Vulnerability{
 							{
 								VulnerabilityCommon: v1alpha1.VulnerabilityCommon{
@@ -154,8 +156,10 @@ func TestParseVulnResults(t *testing.T) {
 							Distro:         &v1alpha1.Distro{Name: "alpine", Version: "3.16.3"},
 							Resources:      map[string][]string{"Deployment": {"apps/app1", "apps/app2"}},
 							TotalResources: 2,
-							Summary:        v1alpha1.VulnerabilitySummary{Total: 2, Critical: 1, High: 1},
+							Summary:        v1alpha1.VulnerabilitySummary{Total: 3, Critical: 1, High: 2},
 						},
+						TotalPackages:       4,
+						TotalUniquePackages: 3,
 						Vulnerabilities: []v1alpha2.Vulnerability{
 							{
 								VulnerabilityCommon: v1alpha1.VulnerabilityCommon{
@@ -204,6 +208,27 @@ func TestParseVulnResults(t *testing.T) {
 									Type:       "python-pkg",
 								}},
 							},
+							{
+								Packages: []v1alpha1.Package{
+									{
+										Package:    "libssl1.1",
+										Version:    "1.1.1s-r0",
+										FixVersion: "1.1.1t-r0",
+										Status:     "fixed",
+										Type:       "alpine",
+									},
+								},
+								VulnerabilityCommon: v1alpha1.VulnerabilityCommon{
+									ID:               "CVE-2023-0286",
+									Severity:         "HIGH",
+									Title:            "openssl: X.400 address type confusion in X.509 GeneralName",
+									Description:      "There is a type confusion vulnerability relating to X.400 address processing\ninside an X.509 GeneralName. X.400 addresses were parsed as an ASN1_STRING but\nthe public structure definition for GENERAL_NAME incorrectly specified the type\nof the x400Address field as ASN1_TYPE. This field is subsequently interpreted by\nthe OpenSSL function GENERAL_NAME_cmp as an ASN1_TYPE rather than an\nASN1_STRING.\n\nWhen CRL checking is enabled (i.e. the application sets the\nX509_V_FLAG_CRL_CHECK flag), this vulnerability may allow an attacker to pass\narbitrary pointers to a memcmp call, enabling them to read memory contents or\nenact a denial of service. In most cases, the attack requires the attacker to\nprovide both the certificate chain and CRL, neither of which need to have a\nvalid signature. If the attacker only controls one of these inputs, the other\ninput must already contain an X.400 address as a CRL distribution point, which\nis uncommon. As such, this vulnerability is most likely to only affect\napplications which have implemented their own functionality for retrieving CRLs\nover a network.\n\n",
+									URL:              "https://avd.aquasec.com/nvd/cve-2023-0286",
+									Score:            "7.4",
+									PublishedDate:    newTime("2023-02-08T20:15:24.267Z"),
+									LastModifiedDate: newTime("2024-02-04T09:15:09.113Z"),
+								},
+							},
 						},
 					},
 				},
@@ -228,6 +253,8 @@ func TestParseVulnResults(t *testing.T) {
 							TotalResources: 1,
 							Summary:        v1alpha1.VulnerabilitySummary{Total: 3, High: 1, Medium: 1, Unknown: 1},
 						},
+						TotalPackages:       3,
+						TotalUniquePackages: 3,
 						Vulnerabilities: []v1alpha2.Vulnerability{
 							{
 								VulnerabilityCommon: v1alpha1.VulnerabilityCommon{
@@ -309,6 +336,8 @@ func TestParseVulnResults(t *testing.T) {
 							TotalResources: 1,
 							Summary:        v1alpha1.VulnerabilitySummary{Total: 2, High: 1, Low: 1},
 						},
+						TotalPackages:       2,
+						TotalUniquePackages: 2,
 						Vulnerabilities: []v1alpha2.Vulnerability{
 							{
 								VulnerabilityCommon: v1alpha1.VulnerabilityCommon{
@@ -372,6 +401,8 @@ func TestParseVulnResults(t *testing.T) {
 							Resources:      map[string][]string{"Deployment": {"default/nginx"}},
 							Summary:        v1alpha1.VulnerabilitySummary{Total: 1, Medium: 1},
 						},
+						TotalPackages:       1,
+						TotalUniquePackages: 1,
 						Vulnerabilities: []v1alpha2.Vulnerability{
 							{
 								VulnerabilityCommon: v1alpha1.VulnerabilityCommon{


### PR DESCRIPTION
## Description
This PR includes the fields `totalPackages` and `totalUniquePackages` in VulnerabilityReport v1alpha2.
Note that v1alpha2 version is not released yet.

## Linked Issues
UD-1454

## How has this been tested?
- Running unit tests: `make test`
- Scanning with this version and checking those new fields.

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [x] My changes are covered by tests
