### PR TITLE
fix: removing underscore from VulnerabilityReport names

### DIFF
--- a/pkg/worker/vuln.go
+++ b/pkg/worker/vuln.go
@@ -39,7 +39,7 @@ var vulnReportTypeMeta = metav1.TypeMeta{
 	APIVersion: v1alpha2.SchemeGroupVersion.String(),
 }
 
-var nonAlphanumericRegex = regexp.MustCompile(`\W+`)
+var nonAlphanumericRegex = regexp.MustCompile(`[\W|_]+`)
 
 func handleVulnerability(ctx context.Context, cfg *config, results io.Reader, client *zora.Clientset) error {
 	log := logr.FromContextOrDiscard(ctx)

--- a/pkg/worker/vuln_test.go
+++ b/pkg/worker/vuln_test.go
@@ -481,3 +481,24 @@ func newTime(s string) *metav1.Time {
 	}
 	return &metav1.Time{Time: p}
 }
+
+func Test_cleanString(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  string
+		want string
+	}{
+		{
+			name: "ok",
+			arg:  `asdfghjklç"!@#$%¨&*()_+'1234567890-=¬¹²³£¢¬{[]}\§[]{}ªº´~^,.;/<>:?°\|àáãâ`,
+			want: "asdfghjkl1234567890",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cleanString(tt.arg); got != tt.want {
+				t.Errorf("cleanString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
This PR fixes a bug in worker container when creating VulnerabilityReports for images named with underscore.

```
2024-06-05T20:06:48Z	ERROR	worker	failed to run worker	{"error": "failed to create VulnerabilityReport \"kind-kind-mfmoraesnginxx86_64latest-q758l\": VulnerabilityReport.zora.undistro.io \"kind-kind-mfmoraesnginxx86_64latest-q758l\" is invalid: metadata.name: Invalid value: \"kind-kind-mfmoraesnginxx86_64latest-q758l\": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')"}
main.main
	/workspace/cmd/worker/main.go:42
runtime.main
	/usr/local/go/src/runtime/proc.go:267
```

## Linked Issues
UD-1516

## How has this been tested?

1. Create a cluster and run a pod with an image named with underscore:
```
kind create cluster
kubectl run nginx --image=mfmoraes/nginxx86_64:latest --image-pull-policy=IfNotPresent
```
2. Install Zora and wait for the vulnerability scan.

3. Check if a vulnerability report for `mfmoraes/nginxx86_64:latest` image is created.
```
kubectl get vulns -n zora-system | grep nginx
```

4. We expect to see:
```
kind-kind-mfmoraesnginxx8664latest-6m7rk                               kind-kind   mfmoraes/nginxx86_64:latest                                   102     2          15     86s
```

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [x] My changes are covered by tests
