### PR TITLE
UD-1517: change name of the pvc and make sure files are accessible to…

### DIFF
--- a/charts/zora/templates/operator/deployment.yaml
+++ b/charts/zora/templates/operator/deployment.yaml
@@ -103,7 +103,7 @@ spec:
             - --worker-image={{ printf "%s:%s" .Values.scan.worker.image.repository (.Values.scan.worker.image.tag | default .Chart.AppVersion) }}
             - --cronjob-clusterrolebinding-name=zora-plugins-rolebinding
             - --cronjob-serviceaccount-name=zora-plugins
-            - --trivy-db-pvc={{- if .Values.scan.plugins.trivy.persistence.enabled }}trivy-db{{- end }}
+            - --trivy-db-pvc={{- if .Values.scan.plugins.trivy.persistence.enabled }}trivy-db-cache{{- end }}
 {{- if .Values.scan.plugins.annotations}}
             - --cronjob-serviceaccount-annotations={{ $first := true }}{{- range $key, $value := .Values.scan.plugins.annotations }}{{if not $first}},{{else}}{{$first = false}}{{end}}{{ $key }}={{$value}}{{- end }}
 {{- end }}

--- a/charts/zora/templates/plugins/trivy-job.yaml
+++ b/charts/zora/templates/plugins/trivy-job.yaml
@@ -24,11 +24,13 @@ spec:
       volumes:
         - name: trivy-db
           persistentVolumeClaim:
-            claimName: trivy-db
+            claimName: trivy-db-cache
       containers:
         - name: trivy-download-db
           image: "{{ .Values.scan.plugins.trivy.image.repository }}:{{ .Values.scan.plugins.trivy.image.tag }}"
-          imagePullPolicy: IfNotPresent
+          {{- if .Values.scan.plugins.trivy.image.pullPolicy }}
+          imagePullPolicy: "{{ .Values.scan.plugins.trivy.image.pullPolicy }}"
+          {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
             privileged: false
@@ -49,7 +51,8 @@ spec:
                 {{- if .Values.scan.plugins.trivy.persistence.downloadJavaDB }}
                 --download-java-db-only \
                 {{- end }}
-                --download-db-only
+                --download-db-only \
+              && chgrp -R 0 /tmp/trivy-cache/* && chmod -R g+rwX /tmp/trivy-cache/*
           env:
             - name: SSL_CERT_DIR
               value: "/etc/ssl/:/run/secrets/kubernetes.io/serviceaccount/"

--- a/charts/zora/templates/plugins/trivy-pvc.yaml
+++ b/charts/zora/templates/plugins/trivy-pvc.yaml
@@ -16,7 +16,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: trivy-db
+  name: trivy-db-cache
 spec:
   {{- if .Values.scan.plugins.trivy.persistence.storageClass }}
   storageClassName: {{ .Values.scan.plugins.trivy.persistence.storageClass | quote }}


### PR DESCRIPTION
… the group

## Description
This PR uses a different PVC name during installation, this is to ensure a clean start/download for the trivy database during upgrade as well as installation.

## Linked Issues

## How has this been tested?
- Install 0.8.4, then upgrade to 0.9.0
- Check output of the trivy-download-job and the trivy scan to ensure they run successfully

## Checklist
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [ ] I have documented my code (if applicable)
- [ ] My changes are covered by tests
