### PR TITLE
UD-1532: remove recursive chgrp/chmod from trivy download job

### DIFF
--- a/charts/zora/templates/plugins/trivy-job.yaml
+++ b/charts/zora/templates/plugins/trivy-job.yaml
@@ -53,8 +53,7 @@ spec:
                 {{- if .Values.scan.plugins.trivy.persistence.downloadJavaDB }}
                 --download-java-db-only \
                 {{- end }}
-                --download-db-only \
-              && chgrp -R {{ .Values.scan.plugins.trivy.persistence.fsGroup }} /tmp/trivy-cache/* && chmod -R g+rwX /tmp/trivy-cache/*
+                --download-db-only
           env:
             - name: SSL_CERT_DIR
               value: "/etc/ssl/:/run/secrets/kubernetes.io/serviceaccount/"


### PR DESCRIPTION
## Description
Rermove recursive chgrp and chmod from the trivy download job

## Linked Issues

## How has this been tested?
- Upgrading from 0.8.4
- Ensure trivy download job runs
- Ensure trivy scan runs

## Checklist
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [ ] I have documented my code (if applicable)
- [ ] My changes are covered by tests
