### PR TITLE
UD-1541: Ensure both databases are downloaded on startup

### DIFF
--- a/charts/zora/templates/plugins/trivy-job.yaml
+++ b/charts/zora/templates/plugins/trivy-job.yaml
@@ -50,10 +50,16 @@ spec:
                 {{- if .Values.scan.plugins.trivy.insecure }}
                 --insecure \
                 {{- end }}
-                {{- if .Values.scan.plugins.trivy.persistence.downloadJavaDB }}
-                --download-java-db-only \
+                --download-db-only{{- if .Values.scan.plugins.trivy.persistence.downloadJavaDB }} && \
+              time trivy image \
+                --debug \
+                --no-progress \
+                --cache-dir=/tmp/trivy-cache \
+                {{- if .Values.scan.plugins.trivy.insecure }}
+                --insecure \
                 {{- end }}
-                --download-db-only
+                --download-java-db-only
+              {{- end }}
           env:
             - name: SSL_CERT_DIR
               value: "/etc/ssl/:/run/secrets/kubernetes.io/serviceaccount/"


### PR DESCRIPTION
## Description
Change job description to run both downloads if java database is also requested

## Linked Issues

## How has this been tested?
- Install with default, ensuring the trivy database (trivy.db) is downloaded
- Install with `downloadJavaDB` set to true, ensure both databases are downloaded and persisted.
- Log of job file can be used to verify, both trivy-db and trivy-java-db should be downloaded

## Checklist
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [ ] I have documented my code (if applicable)
- [ ] My changes are covered by tests
