### PR TITLE
Update default PVC size in documentation

### DIFF
--- a/docs/configuration/vulnerability-database-persistence.md
+++ b/docs/configuration/vulnerability-database-persistence.md
@@ -22,7 +22,7 @@ This persistence can be disabled or configured with the following Helm parameter
 | scan.plugins.trivy.persistence.enabled        | bool   | `true`            | Specifies whether Trivy vulnerabilities database should be persisted between the scans, using PersistentVolumeClaim               |
 | scan.plugins.trivy.persistence.accessMode     | string | `"ReadWriteOnce"` | [Persistence access mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes)                           |
 | scan.plugins.trivy.persistence.storageClass   | string | `""`              | [Persistence storage class](https://kubernetes.io/docs/concepts/storage/storage-classes/). Set to empty for default storage class |
-| scan.plugins.trivy.persistence.storageRequest | string | `"1Gi"`           | Persistence storage size                                                                                                          |
+| scan.plugins.trivy.persistence.storageRequest | string | `"2Gi"`           | Persistence storage size                                                                                                          |
 | scan.plugins.trivy.persistence.downloadJavaDB | bool   | `false`           | Specifies whether Java vulnerability database should be downloaded on helm install/upgrade                                        |
 
 These parameters can be specified using the `--set key=value` argument in `helm upgrade --install` command.


### PR DESCRIPTION
## Description
Update default PVC size in documentation (`vulnerability-database-persistence.md`)

## Linked Issues
https://github.com/undistro/zora/pull/294

## How has this been tested?
- Checking the documentation

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [ ] My changes are covered by tests
