### PR TITLE
fix VulnerabilityReport `totalUniquePackages`

### DIFF
--- a/api/zora/v1alpha2/vulnerabilityreport_types.go
+++ b/api/zora/v1alpha2/vulnerabilityreport_types.go
@@ -54,7 +54,7 @@ func (in *VulnerabilityReportSpec) Summarize() {
 		}
 		for _, p := range v.Packages {
 			total++
-			unique[p.String()] = true
+			unique[p.Package+p.Version] = true
 		}
 	}
 	in.Summary = *s


### PR DESCRIPTION
## Description
This PR fixes the count of unique packages in VulnerabilityReport.

The package `libc6` at version `2.36-9+deb12u4` in the example below is counted twice because has different status for each CVE (`fixed` vs `affected`).

The expected behavior is to be counted as the same package. Note that it’s a vulnerability report of one image.
```yaml
    id: CVE-2024-33600
    packages:
    - fixVersion: 2.36-9+deb12u7
      package: libc6
      status: fixed
      type: debian
      version: 2.36-9+deb12u4
---
    id: CVE-2019-1010023
    packages:
    - package: libc6
      status: affected
      type: debian
      version: 2.36-9+deb12u4
```

## Linked Issues
UD-1592

## How has this been tested?
- Install Zora in a cluster with vulnerability scan enabled, and check the field `totalUniquePackages` of VulnerabilityReports

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [x] My changes are covered by tests
