### PR TITLE
chore: specify Go patch version 1.22.5

### DIFF
--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22 as builder
+FROM golang:1.22.5 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22.5 AS builder
+FROM golang:1.22 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/cmd/worker/Dockerfile
+++ b/cmd/worker/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22 as builder
+FROM golang:1.22.5 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/cmd/worker/Dockerfile
+++ b/cmd/worker/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22.5 AS builder
+FROM golang:1.22 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/undistro/zora
 
-go 1.22.0
+go 1.22.5
 
 require (
 	github.com/aquasecurity/trivy v0.51.2


### PR DESCRIPTION
## Description
This PR specifies the Go patch version 1.22.5 to avoid some vulnerabilities.

Before:
```
trivy image ghcr.io/undistro/zora/operator:v0.9.2
2024-07-31T10:06:56-03:00	INFO	Need to update DB
2024-07-31T10:06:56-03:00	INFO	Downloading DB...	repository="ghcr.io/aquasecurity/trivy-db:2"
50.74 MiB / 50.74 MiB [----------------------------------------------------------------------------------------------------] 100.00% 5.84 MiB p/s 8.9s
2024-07-31T10:07:06-03:00	INFO	Vulnerability scanning is enabled
2024-07-31T10:07:06-03:00	INFO	Secret scanning is enabled
2024-07-31T10:07:06-03:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-07-31T10:07:06-03:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.52/docs/scanner/secret/#recommendation for faster secret detection
2024-07-31T10:07:12-03:00	INFO	Detected OS	family="debian" version="12.5"
2024-07-31T10:07:12-03:00	INFO	[debian] Detecting vulnerabilities...	os_version="12" pkg_num=3
2024-07-31T10:07:12-03:00	INFO	Number of language-specific files	num=1
2024-07-31T10:07:12-03:00	INFO	[gobinary] Detecting vulnerabilities...

ghcr.io/undistro/zora/operator:v0.9.2 (debian 12.5)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)


manager (gobinary)

Total: 2 (UNKNOWN: 0, LOW: 0, MEDIUM: 2, HIGH: 0, CRITICAL: 0)

┌──────────────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬──────────────────────────────────────────────────────────┐
│     Library      │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                          Title                           │
├──────────────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼──────────────────────────────────────────────────────────┤
│ golang.org/x/net │ CVE-2023-45288 │ MEDIUM   │ fixed  │ v0.21.0           │ 0.23.0          │ golang: net/http, x/net/http2: unlimited number of       │
│                  │                │          │        │                   │                 │ CONTINUATION frames causes DoS                           │
│                  │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2023-45288               │
├──────────────────┼────────────────┤          │        ├───────────────────┼─────────────────┼──────────────────────────────────────────────────────────┤
│ stdlib           │ CVE-2024-24791 │          │        │ 1.21.11           │ 1.21.12, 1.22.5 │ net/http: Denial of service due to improper 100-continue │
│                  │                │          │        │                   │                 │ handling in net/http                                     │
│                  │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24791               │
└──────────────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴──────────────────────────────────────────────────────────┘
```

Now:
```
trivy image operator:latest
2024-07-31T10:11:24-03:00       INFO    Vulnerability scanning is enabled
2024-07-31T10:11:24-03:00       INFO    Secret scanning is enabled
2024-07-31T10:11:24-03:00       INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-07-31T10:11:24-03:00       INFO    Please see also https://aquasecurity.github.io/trivy/v0.52/docs/scanner/secret/#recommendation for faster secret detection
2024-07-31T10:11:26-03:00       INFO    Detected OS     family="debian" version="11.7"
2024-07-31T10:11:26-03:00       INFO    [debian] Detecting vulnerabilities...   os_version="11" pkg_num=3
2024-07-31T10:11:26-03:00       INFO    Number of language-specific files       num=1
2024-07-31T10:11:26-03:00       INFO    [gobinary] Detecting vulnerabilities...

operator:latest (debian 11.7)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```

## Linked Issues

## How has this been tested?
Building a docker image `make docker-build` and scanning with Trivy `trivy image operator:latest`.
Note that the project was already using Go 1.22.

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [ ] I have documented my code (if applicable)
- [ ] My changes are covered by tests
