### PR TITLE
UD-1682: address pod security admission warnings, fix service account…

### DIFF
--- a/charts/zora/README.md
+++ b/charts/zora/README.md
@@ -124,7 +124,6 @@ The following table lists the configurable parameters of the Zora chart and thei
 | scan.plugins.trivy.timeout | string | `"10m"` | Trivy timeout |
 | scan.plugins.trivy.insecure | bool | `false` | Allow insecure server connections for Trivy |
 | scan.plugins.trivy.persistence.enabled | bool | `true` | Specifies whether Trivy vulnerabilities database should be persisted between the scans, using PersistentVolumeClaim |
-| scan.plugins.trivy.persistence.fsGroup | int | `0` | Specifies the fsGroup to use when mounting the persistent volume |
 | scan.plugins.trivy.persistence.accessMode | string | `"ReadWriteOnce"` | [Persistence access mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) |
 | scan.plugins.trivy.persistence.storageClass | string | `""` | [Persistence storage class](https://kubernetes.io/docs/concepts/storage/storage-classes/). Set to empty for default storage class |
 | scan.plugins.trivy.persistence.storageRequest | string | `"2Gi"` | Persistence storage size |

--- a/charts/zora/templates/hooks/delete.yaml
+++ b/charts/zora/templates/hooks/delete.yaml
@@ -66,5 +66,10 @@ spec:
         - --ignore-not-found=true
       securityContext:
         allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
         readOnlyRootFilesystem: true
+        seccompProfile:
+          type: "RuntimeDefault"
   restartPolicy: Never

--- a/charts/zora/templates/hooks/install.yaml
+++ b/charts/zora/templates/hooks/install.yaml
@@ -49,6 +49,11 @@ spec:
               "revision" .Release.Revision) }}'
       securityContext:
         allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
         readOnlyRootFilesystem: true
+        seccompProfile:
+          type: "RuntimeDefault"
   restartPolicy: Never
 {{- end }}

--- a/charts/zora/templates/operator/deployment.yaml
+++ b/charts/zora/templates/operator/deployment.yaml
@@ -103,8 +103,7 @@ spec:
             - --worker-image={{ printf "%s:%s" .Values.scan.worker.image.repository (.Values.scan.worker.image.tag | default .Chart.AppVersion) }}
             - --cronjob-clusterrolebinding-name=zora-plugins-rolebinding
             - --cronjob-serviceaccount-name=zora-plugins
-            - --trivy-db-pvc={{- if .Values.scan.plugins.trivy.persistence.enabled }}trivy-db-pvc{{- end }}
-            - --trivy-db-fsgroup={{ .Values.scan.plugins.trivy.persistence.fsGroup }}
+            - --trivy-db-pvc={{- if .Values.scan.plugins.trivy.persistence.enabled }}trivy-db-volume{{- end }}
 {{- if .Values.scan.plugins.annotations}}
             - --cronjob-serviceaccount-annotations={{ $first := true }}{{- range $key, $value := .Values.scan.plugins.annotations }}{{if not $first}},{{else}}{{$first = false}}{{end}}{{ $key }}={{$value}}{{- end }}
 {{- end }}

--- a/charts/zora/templates/plugins/trivy-job.yaml
+++ b/charts/zora/templates/plugins/trivy-job.yaml
@@ -21,12 +21,10 @@ spec:
   ttlSecondsAfterFinished: 0
   template:
     spec:
-      securityContext:
-        fsGroup: 0
       volumes:
         - name: trivy-db
           persistentVolumeClaim:
-            claimName: trivy-db-pvc
+            claimName: trivy-db-volume
       containers:
         - name: trivy-download-db
           image: "{{ .Values.scan.plugins.trivy.image.repository }}:{{ .Values.scan.plugins.trivy.image.tag }}"
@@ -35,7 +33,13 @@ spec:
           {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
             privileged: false
+            runAsNonRoot: true
+            seccompProfile:
+              type: "RuntimeDefault"
           volumeMounts:
             - mountPath: /tmp/trivy-cache
               name: trivy-db
@@ -70,4 +74,5 @@ spec:
               value: {{ .Values.noProxy | quote }}
             {{- end }}
       restartPolicy: OnFailure
+      serviceAccountName: zora-plugins
 {{- end }}

--- a/charts/zora/templates/plugins/trivy-pvc.yaml
+++ b/charts/zora/templates/plugins/trivy-pvc.yaml
@@ -16,7 +16,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: trivy-db-pvc
+  name: trivy-db-volume
 spec:
   {{- if .Values.scan.plugins.trivy.persistence.storageClass }}
   storageClassName: {{ .Values.scan.plugins.trivy.persistence.storageClass | quote }}

--- a/charts/zora/values.yaml
+++ b/charts/zora/values.yaml
@@ -238,8 +238,6 @@ scan:
       persistence:
         # -- Specifies whether Trivy vulnerabilities database should be persisted between the scans, using PersistentVolumeClaim
         enabled: true
-        # -- Specifies the fsGroup to use when mounting the persistent volume
-        fsGroup: 0
         # -- [Persistence access mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes)
         accessMode: ReadWriteOnce
         # -- [Persistence storage class](https://kubernetes.io/docs/concepts/storage/storage-classes/). Set to empty for default storage class

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -82,7 +82,6 @@ func main() {
 	var kubexnsImage string
 	var kubexnsPullPolicy string
 	var trivyPVC string
-	var trivyFSGroup int64
 	var updateCRDs bool
 	var injectConversion bool
 	var caPath string
@@ -113,7 +112,6 @@ func main() {
 	flag.StringVar(&kubexnsImage, "kubexns-image", "ghcr.io/undistro/kubexns:latest", "kubexns image")
 	flag.StringVar(&kubexnsPullPolicy, "kubexns-pull-policy", "Always", "kubexns image pull policy")
 	flag.StringVar(&trivyPVC, "trivy-db-pvc", "", "PersistentVolumeClaim name for Trivy DB")
-	flag.Int64Var(&trivyFSGroup, "trivy-db-fsgroup", 0, "PersistentVolumeClaim FSGroup for Trivy DB")
 	flag.BoolVar(&updateCRDs, "update-crds", false,
 		"If set to true, operator will update Zora CRDs if needed")
 	flag.BoolVar(&injectConversion, "inject-conversion", false,
@@ -222,7 +220,6 @@ func main() {
 		KubexnsImage:            kubexnsImage,
 		KubexnsPullPolicy:       kubexnsPullPolicy,
 		TrivyPVC:                trivyPVC,
-		TrivyFSGroup:            &trivyFSGroup,
 		ChecksConfigMap:         fmt.Sprintf("%s/%s", checksConfigMapNamespace, checksConfigMapName),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ClusterScan")

--- a/internal/controller/zora/clusterscan_controller.go
+++ b/internal/controller/zora/clusterscan_controller.go
@@ -65,7 +65,6 @@ type ClusterScanReconciler struct {
 	KubexnsPullPolicy       string
 	ChecksConfigMap         string
 	TrivyPVC                string
-	TrivyFSGroup            *int64
 	Annotations             map[string]string
 	OnUpdate                saas.ClusterScanHook
 	OnDelete                saas.ClusterScanHook
@@ -222,7 +221,6 @@ func (r *ClusterScanReconciler) reconcile(ctx context.Context, clusterscan *v1al
 			KubexnsPullPolicy:  r.KubexnsPullPolicy,
 			ChecksConfigMap:    r.ChecksConfigMap,
 			TrivyPVC:           r.TrivyPVC,
-			TrivyFSGroup:       r.TrivyFSGroup,
 			ClusterUID:         cluster.UID,
 		}
 

--- a/pkg/plugins/cronjob.go
+++ b/pkg/plugins/cronjob.go
@@ -98,7 +98,6 @@ type CronJobMutator struct {
 	KubexnsPullPolicy  string
 	ChecksConfigMap    string
 	TrivyPVC           string
-	TrivyFSGroup       *int64
 	ClusterUID         types.UID
 }
 
@@ -153,11 +152,6 @@ func (r *CronJobMutator) Mutate() error {
 				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: r.TrivyPVC},
 			},
 		})
-		if r.TrivyFSGroup != nil {
-			r.Existing.Spec.JobTemplate.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
-				FSGroup: r.TrivyFSGroup,
-			}
-		}
 	}
 
 	if pointer.BoolDeref(r.Plugin.Spec.MountCustomChecksVolume, false) {


### PR DESCRIPTION
… name usage for download job

## Description
Fix PSA warnings from openshift, part of which is to fix the service account name usage within the download job and remove the fsGroup.

Note the PVC name is changed for upgrades

## Linked Issues

## How has this been tested?
- Deploying on OpenShift, checking for warnings and running a trivy scan.

## Checklist
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [ ] I have documented my code (if applicable)
- [ ] My changes are covered by tests
