### PR TITLE
UD-1393: specify default resource values for Trivy scan

### DIFF
--- a/charts/zora/README.md
+++ b/charts/zora/README.md
@@ -114,7 +114,7 @@ The following table lists the configurable parameters of the Zora chart and thei
 | scan.plugins.marvin.envFrom | list | `[]` | List of sources to populate environment variables in marvin container. |
 | scan.plugins.trivy.ignoreUnfixed | bool | `false` | Specifies whether only fixed vulnerabilities should be reported |
 | scan.plugins.trivy.ignoreDescriptions | bool | `false` | Specifies whether vulnerability descriptions should be ignored |
-| scan.plugins.trivy.resources | object | `{}` | [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) to add to `trivy` container |
+| scan.plugins.trivy.resources | object | `{"limits":{"cpu":"1500m","memory":"4096Mi"},"requests":{"cpu":500,"memory":"2048Mi"}}` | [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) to add to `trivy` container |
 | scan.plugins.trivy.podAnnotations | object | `{}` | Annotations added to the trivy pods |
 | scan.plugins.trivy.image.repository | string | `"ghcr.io/undistro/trivy"` | trivy plugin image repository |
 | scan.plugins.trivy.image.tag | float | `0.53` | trivy plugin image tag |

--- a/charts/zora/values.yaml
+++ b/charts/zora/values.yaml
@@ -206,7 +206,13 @@ scan:
       # -- Specifies whether vulnerability descriptions should be ignored
       ignoreDescriptions: false
       # -- [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) to add to `trivy` container
-      resources: {}
+      resources:
+        requests:
+          cpu: 500
+          memory: 2048Mi
+        limits:
+          cpu: 1500m
+          memory: 4096Mi
       # -- Annotations added to the trivy pods
       podAnnotations: {}
       image:


### PR DESCRIPTION
## Description
Default resource values for trivy scans

## Linked Issues

## How has this been tested?
- Analysis of heap while running against a default openshift installation

## Checklist
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [ ] I have documented my code (if applicable)
- [ ] My changes are covered by tests
