### PR TITLE
Add fsGroup variable for Trivy plugin

### DIFF
--- a/charts/zora/Chart.yaml
+++ b/charts/zora/Chart.yaml
@@ -17,7 +17,7 @@ name: zora
 description: A multi-plugin solution that reports misconfigurations and vulnerabilities by scanning your cluster at scheduled times.
 icon: https://zora-docs.undistro.io/v0.7/assets/logo.svg
 type: application
-version: 0.10.2-rc1
-appVersion: "v0.10.2-rc1"
+version: 0.10.2
+appVersion: "v0.10.2"
 sources:
   - https://github.com/undistro/zora

--- a/charts/zora/Chart.yaml
+++ b/charts/zora/Chart.yaml
@@ -17,7 +17,7 @@ name: zora
 description: A multi-plugin solution that reports misconfigurations and vulnerabilities by scanning your cluster at scheduled times.
 icon: https://zora-docs.undistro.io/v0.7/assets/logo.svg
 type: application
-version: 0.10.1
-appVersion: "v0.10.1"
+version: 0.10.2-rc1
+appVersion: "v0.10.2-rc1"
 sources:
   - https://github.com/undistro/zora

--- a/charts/zora/README.md
+++ b/charts/zora/README.md
@@ -123,6 +123,7 @@ The following table lists the configurable parameters of the Zora chart and thei
 | scan.plugins.trivy.envFrom | list | `[]` | List of sources to populate environment variables in trivy container. |
 | scan.plugins.trivy.timeout | string | `"10m"` | Trivy timeout |
 | scan.plugins.trivy.insecure | bool | `false` | Allow insecure server connections for Trivy |
+| scan.plugins.trivy.fsGroup | int | `nil` | Trivy fsGroup. Should be greater than 0. |
 | scan.plugins.trivy.persistence.enabled | bool | `true` | Specifies whether Trivy vulnerabilities database should be persisted between the scans, using PersistentVolumeClaim |
 | scan.plugins.trivy.persistence.accessMode | string | `"ReadWriteOnce"` | [Persistence access mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) |
 | scan.plugins.trivy.persistence.storageClass | string | `""` | [Persistence storage class](https://kubernetes.io/docs/concepts/storage/storage-classes/). Set to empty for default storage class |

--- a/charts/zora/README.md
+++ b/charts/zora/README.md
@@ -1,6 +1,6 @@
 # Zora Helm Chart
 
-![Version: 0.10.1](https://img.shields.io/badge/Version-0.10.1-informational?style=flat-square&color=3CA9DD) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square&color=3CA9DD) ![AppVersion: v0.10.1](https://img.shields.io/badge/AppVersion-v0.10.1-informational?style=flat-square&color=3CA9DD)
+![Version: 0.10.2](https://img.shields.io/badge/Version-0.10.2-informational?style=flat-square&color=3CA9DD) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square&color=3CA9DD) ![AppVersion: v0.10.2](https://img.shields.io/badge/AppVersion-v0.10.2-informational?style=flat-square&color=3CA9DD)
 
 A multi-plugin solution that reports misconfigurations and vulnerabilities by scanning your cluster at scheduled times.
 
@@ -13,7 +13,7 @@ helm repo add undistro https://charts.undistro.io --force-update
 helm repo update undistro
 helm upgrade --install zora undistro/zora \
   -n zora-system \
-  --version 0.10.1 \
+  --version 0.10.2 \
   --create-namespace \
   --wait \
   --set clusterName="$(kubectl config current-context)"

--- a/charts/zora/templates/operator/deployment.yaml
+++ b/charts/zora/templates/operator/deployment.yaml
@@ -105,6 +105,7 @@ spec:
             - --cronjob-clusterrolebinding-name=zora-plugins-rolebinding
             - --cronjob-serviceaccount-name=zora-plugins
             - --trivy-db-pvc={{- if .Values.scan.plugins.trivy.persistence.enabled }}trivy-db-volume{{- end }}
+            - --trivy-fs-group={{- if .Values.scan.plugins.trivy.fsGroup }}{{ .Values.scan.plugins.trivy.fsGroup }}{{- else }}0{{- end}}
 {{- if .Values.scan.plugins.annotations}}
             - --cronjob-serviceaccount-annotations={{ $first := true }}{{- range $key, $value := .Values.scan.plugins.annotations }}{{if not $first}},{{else}}{{$first = false}}{{end}}{{ $key }}={{$value}}{{- end }}
 {{- end }}

--- a/charts/zora/templates/plugins/trivy-job.yaml
+++ b/charts/zora/templates/plugins/trivy-job.yaml
@@ -25,6 +25,10 @@ spec:
         - name: trivy-db
           persistentVolumeClaim:
             claimName: trivy-db-volume
+      {{- if .Values.scan.plugins.trivy.fsGroup }}
+      securityContext:
+        fsGroup: {{ .Values.scan.plugins.trivy.fsGroup }}
+      {{- end }}
       containers:
         - name: trivy-download-db
           image: "{{ .Values.scan.plugins.trivy.image.repository }}:{{ .Values.scan.plugins.trivy.image.tag }}"

--- a/charts/zora/values.yaml
+++ b/charts/zora/values.yaml
@@ -241,6 +241,9 @@ scan:
       # -- Allow insecure server connections for Trivy
       insecure: false
 
+      # -- (int) Trivy fsGroup. Should be greater than 0.
+      fsGroup: null
+
       persistence:
         # -- Specifies whether Trivy vulnerabilities database should be persisted between the scans, using PersistentVolumeClaim
         enabled: true

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -82,6 +82,7 @@ func main() {
 	var kubexnsImage string
 	var kubexnsPullPolicy string
 	var trivyPVC string
+	var trivyFSGroup int64
 	var updateCRDs bool
 	var injectConversion bool
 	var caPath string
@@ -113,6 +114,7 @@ func main() {
 	flag.StringVar(&kubexnsImage, "kubexns-image", "ghcr.io/undistro/kubexns:latest", "kubexns image")
 	flag.StringVar(&kubexnsPullPolicy, "kubexns-pull-policy", "Always", "kubexns image pull policy")
 	flag.StringVar(&trivyPVC, "trivy-db-pvc", "", "PersistentVolumeClaim name for Trivy DB")
+	flag.Int64Var(&trivyFSGroup, "trivy-fs-group", 0, "fsGroup for Trivy")
 	flag.BoolVar(&updateCRDs, "update-crds", false,
 		"If set to true, operator will update Zora CRDs if needed")
 	flag.BoolVar(&injectConversion, "inject-conversion", false,
@@ -226,6 +228,7 @@ func main() {
 		KubexnsImage:            kubexnsImage,
 		KubexnsPullPolicy:       kubexnsPullPolicy,
 		TrivyPVC:                trivyPVC,
+		TrivyFSGroup:            trivyFSGroup,
 		ChecksConfigMap:         fmt.Sprintf("%s/%s", checksConfigMapNamespace, checksConfigMapName),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ClusterScan")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -108,7 +108,7 @@ func main() {
 	flag.StringVar(&cronJobAnnotations, "cronjob-serviceaccount-annotations", "annotaion1=value1,annotation2=value2", "Annotations to be applied to the CronJob Service Account")
 	flag.StringVar(&saasWorkspaceID, "saas-workspace-id", "", "Your workspace ID in Zora SaaS")
 	flag.StringVar(&saasServer, "saas-server", "http://localhost:3003", "Address for Zora's saas server")
-	flag.StringVar(&version, "version", "0.10.1", "Zora version")
+	flag.StringVar(&version, "version", "0.10.2", "Zora version")
 	flag.StringVar(&checksConfigMapNamespace, "checks-configmap-namespace", "zora-system", "Namespace of custom checks ConfigMap")
 	flag.StringVar(&checksConfigMapName, "checks-configmap-name", "zora-custom-checks", "Name of custom checks ConfigMap")
 	flag.StringVar(&kubexnsImage, "kubexns-image", "ghcr.io/undistro/kubexns:latest", "kubexns image")

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -31,7 +31,7 @@ Then, run the following command to install Zora [Helm chart](https://helm.sh/doc
     helm repo update undistro
     helm upgrade --install zora undistro/zora \
       -n zora-system \
-      --version 0.10.1 \
+      --version 0.10.2 \
       --create-namespace \
       --wait \
       --set clusterName="$(kubectl config current-context)"
@@ -42,7 +42,7 @@ Then, run the following command to install Zora [Helm chart](https://helm.sh/doc
     ```shell
     helm upgrade --install zora oci://ghcr.io/undistro/helm-charts/zora \
       -n zora-system \
-      --version 0.10.1 \
+      --version 0.10.2 \
       --create-namespace \
       --wait \
       --set clusterName="$(kubectl config current-context)"

--- a/internal/controller/zora/clusterscan_controller.go
+++ b/internal/controller/zora/clusterscan_controller.go
@@ -65,6 +65,7 @@ type ClusterScanReconciler struct {
 	KubexnsPullPolicy       string
 	ChecksConfigMap         string
 	TrivyPVC                string
+	TrivyFSGroup            int64
 	Annotations             map[string]string
 	OnUpdate                saas.ClusterScanHook
 	OnDelete                saas.ClusterScanHook
@@ -221,6 +222,7 @@ func (r *ClusterScanReconciler) reconcile(ctx context.Context, clusterscan *v1al
 			KubexnsPullPolicy:  r.KubexnsPullPolicy,
 			ChecksConfigMap:    r.ChecksConfigMap,
 			TrivyPVC:           r.TrivyPVC,
+			TrivyFSGroup:       r.TrivyFSGroup,
 			ClusterUID:         cluster.UID,
 		}
 


### PR DESCRIPTION
## Description
This PR adds the variable `scan.plugins.trivy.fsGroup` in Helm Chart.

## Linked Issues
UD-1774

## How has this been tested?
- checking the default value: `helm template zora charts/zora --set clusterName=test > template.yaml`
- checking the provided value: `helm template zora charts/zora --set clusterName=test --set scan.plugins.trivy.fsGroup=2000 > template.yaml`


## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [ ] My changes are covered by tests
