### PR TITLE
Revert back to UD-1521 fsgroup behaviour and include runAsGroup

### DIFF
--- a/charts/zora/README.md
+++ b/charts/zora/README.md
@@ -123,7 +123,7 @@ The following table lists the configurable parameters of the Zora chart and thei
 | scan.plugins.trivy.envFrom | list | `[]` | List of sources to populate environment variables in trivy container. |
 | scan.plugins.trivy.timeout | string | `"40m"` | Trivy timeout |
 | scan.plugins.trivy.insecure | bool | `false` | Allow insecure server connections for Trivy |
-| scan.plugins.trivy.fsGroup | int | `nil` | Trivy fsGroup. Should be greater than 0. |
+| scan.plugins.trivy.fsGroup | int | `3000` | Specifies the fsGroup to use when mounting the persistent volume. Should be greater than 0. |
 | scan.plugins.trivy.persistence.enabled | bool | `true` | Specifies whether Trivy vulnerabilities database should be persisted between the scans, using PersistentVolumeClaim |
 | scan.plugins.trivy.persistence.accessMode | string | `"ReadWriteOnce"` | [Persistence access mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) |
 | scan.plugins.trivy.persistence.storageClass | string | `""` | [Persistence storage class](https://kubernetes.io/docs/concepts/storage/storage-classes/). Set to empty for default storage class |

--- a/charts/zora/templates/operator/deployment.yaml
+++ b/charts/zora/templates/operator/deployment.yaml
@@ -104,8 +104,8 @@ spec:
             - --worker-image={{ printf "%s:%s" .Values.scan.worker.image.repository (.Values.scan.worker.image.tag | default .Chart.AppVersion) }}
             - --cronjob-clusterrolebinding-name=zora-plugins-rolebinding
             - --cronjob-serviceaccount-name=zora-plugins
-            - --trivy-db-pvc={{- if .Values.scan.plugins.trivy.persistence.enabled }}trivy-db-volume{{- end }}
-            - --trivy-fs-group={{- if .Values.scan.plugins.trivy.fsGroup }}{{ .Values.scan.plugins.trivy.fsGroup }}{{- else }}0{{- end}}
+            - --trivy-db-pvc={{- if .Values.scan.plugins.trivy.persistence.enabled }}trivy-dbs-volume{{- end }}
+            - --trivy-fs-group={{ .Values.scan.plugins.trivy.fsGroup }}
 {{- if .Values.scan.plugins.annotations}}
             - --cronjob-serviceaccount-annotations={{ $first := true }}{{- range $key, $value := .Values.scan.plugins.annotations }}{{if not $first}},{{else}}{{$first = false}}{{end}}{{ $key }}={{$value}}{{- end }}
 {{- end }}

--- a/charts/zora/templates/plugins/trivy-job.yaml
+++ b/charts/zora/templates/plugins/trivy-job.yaml
@@ -24,11 +24,9 @@ spec:
       volumes:
         - name: trivy-db
           persistentVolumeClaim:
-            claimName: trivy-db-volume
-      {{- if .Values.scan.plugins.trivy.fsGroup }}
+            claimName: trivy-dbs-volume
       securityContext:
         fsGroup: {{ .Values.scan.plugins.trivy.fsGroup }}
-      {{- end }}
       containers:
         - name: trivy-download-db
           image: "{{ .Values.scan.plugins.trivy.image.repository }}:{{ .Values.scan.plugins.trivy.image.tag }}"
@@ -42,6 +40,7 @@ spec:
               - ALL
             privileged: false
             runAsNonRoot: true
+            runAsGroup: {{ .Values.scan.plugins.trivy.fsGroup }}
             seccompProfile:
               type: "RuntimeDefault"
           volumeMounts:
@@ -66,8 +65,9 @@ spec:
                 {{- if .Values.scan.plugins.trivy.insecure }}
                 --insecure \
                 {{- end }}
-                --download-java-db-only
-              {{- end }}
+                --download-java-db-only {{- end }} && \
+                find /tmp/trivy-cache ! -group {{ .Values.scan.plugins.trivy.fsGroup }} | xargs -r chgrp -f {{ .Values.scan.plugins.trivy.fsGroup }} && \
+                find /tmp/trivy-cache ! -perm -070 | xargs -r chmod -f g+rwX
           env:
             - name: SSL_CERT_DIR
               value: "/etc/ssl/:/run/secrets/kubernetes.io/serviceaccount/"

--- a/charts/zora/templates/plugins/trivy-pvc.yaml
+++ b/charts/zora/templates/plugins/trivy-pvc.yaml
@@ -16,7 +16,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: trivy-db-volume
+  name: trivy-dbs-volume
 spec:
   {{- if .Values.scan.plugins.trivy.persistence.storageClass }}
   storageClassName: {{ .Values.scan.plugins.trivy.persistence.storageClass | quote }}

--- a/charts/zora/templates/plugins/trivy-scc.yaml
+++ b/charts/zora/templates/plugins/trivy-scc.yaml
@@ -1,0 +1,28 @@
+{{- if .Capabilities.APIVersions.Has "security.openshift.io/v1" }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: zora-scc
+fsGroup:
+  type: MustRunAs
+  ranges:
+  - min: {{ .Values.scan.plugins.trivy.fsGroup }}
+    max: {{ .Values.scan.plugins.trivy.fsGroup }}
+runAsUser:
+  type: MustRunAsNonRoot
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles:
+- runtime/default
+volumes:
+- configMap
+- csi
+- downwardAPI
+- emptyDir
+- ephemeral
+- persistentVolumeClaim
+- projected
+- secret
+users:
+- system:serviceaccount:{{ .Release.Namespace }}:zora-plugins
+{{- end }}

--- a/charts/zora/values.yaml
+++ b/charts/zora/values.yaml
@@ -241,8 +241,8 @@ scan:
       # -- Allow insecure server connections for Trivy
       insecure: false
 
-      # -- (int) Trivy fsGroup. Should be greater than 0.
-      fsGroup: null
+      # -- Specifies the fsGroup to use when mounting the persistent volume. Should be greater than 0.
+      fsGroup: 3000
 
       persistence:
         # -- Specifies whether Trivy vulnerabilities database should be persisted between the scans, using PersistentVolumeClaim


### PR DESCRIPTION
## Description
Revert back to UD-1512 default behaviour and include runAsGroup in containers.

## Linked Issues

## How has this been tested?
- Deployed to local cluster
- Exec into job pod and check persistent volume permissions
- Exec into trivy plugin pod and check persistent volume permissions
- Check job and cronjob yaml to verify fsGroup and runAsGroup entries

## Checklist
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [ ] I have documented my code (if applicable)
- [ ] My changes are covered by tests
