### PR TITLE
Update proxy documentation and tokenrefresh to use HTTP proxy settings from env

### DIFF
--- a/docs/configuration/https-proxy.md
+++ b/docs/configuration/https-proxy.md
@@ -12,14 +12,15 @@ parameter when running `helm upgrade --install` command.
 Additionally, you can specify URLs that should bypass the proxy, by setting the `noProxy` parameter in comma-separated 
 list format. Note that this parameter already has a default value: `kubernetes.default.svc.*,127.0.0.1,localhost`.
 
-Configuring proxy settings enables both `trivy` plugin and `zora-operator` to use the proxy for external requests.
+Configuring proxy settings enables `trivy` plugin, `zora-operator` and `zora-tokenrefresh` to use the proxy for external requests.
 
-Zora OSS sends scan results to the following external URL if your installation is integrated with
-[Zora Dashboard](../dashboard.md):
-
-- `https://zora-dashboard.undistro.io`
+Zora OSS installations integrated with [Zora Dashboard](../dashboard.md) communicate with the addresses below:
+- `https://zora-dashboard.undistro.io` for sending scan results
+- `https://login.undistro.io/oauth/token` for refreshing authentication token
 
 While [Trivy](../plugins/trivy.md) downloads vulnerability databases during scans from the following external sources:
 
 - `ghcr.io/aquasecurity/trivy-db` 
 - `ghcr.io/aquasecurity/trivy-java-db`
+- `mirror.gcr.io/aquasec/trivy-db`
+- `mirror.gcr.io/aquasec/trivy-java-db`


### PR DESCRIPTION
## Description
This PR updates
- proxy documentation to include the missing external addresses
- tokenrefresh to use HTTP proxy settings from env (note that env variables were already set)

## Linked Issues


## How has this been tested?


## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [ ] My changes are covered by tests
