### PR TITLE
Add support to customize Trivy vulnerability database repository

### DIFF
--- a/charts/zora/Chart.yaml
+++ b/charts/zora/Chart.yaml
@@ -17,7 +17,7 @@ name: zora
 description: A multi-plugin solution that reports misconfigurations and vulnerabilities by scanning your cluster at scheduled times.
 icon: https://zora-docs.undistro.io/v0.7/assets/logo.svg
 type: application
-version: 0.10.4
-appVersion: "v0.10.4"
+version: 0.10.5
+appVersion: "v0.10.5"
 sources:
   - https://github.com/undistro/zora

--- a/charts/zora/README.md
+++ b/charts/zora/README.md
@@ -1,6 +1,6 @@
 # Zora Helm Chart
 
-![Version: 0.10.4](https://img.shields.io/badge/Version-0.10.4-informational?style=flat-square&color=3CA9DD) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square&color=3CA9DD) ![AppVersion: v0.10.4](https://img.shields.io/badge/AppVersion-v0.10.4-informational?style=flat-square&color=3CA9DD)
+![Version: 0.10.5](https://img.shields.io/badge/Version-0.10.5-informational?style=flat-square&color=3CA9DD) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square&color=3CA9DD) ![AppVersion: v0.10.5](https://img.shields.io/badge/AppVersion-v0.10.5-informational?style=flat-square&color=3CA9DD)
 
 A multi-plugin solution that reports misconfigurations and vulnerabilities by scanning your cluster at scheduled times.
 
@@ -13,7 +13,7 @@ helm repo add undistro https://charts.undistro.io --force-update
 helm repo update undistro
 helm upgrade --install zora undistro/zora \
   -n zora-system \
-  --version 0.10.4 \
+  --version 0.10.5 \
   --create-namespace \
   --wait \
   --set clusterName="$(kubectl config current-context)"

--- a/charts/zora/README.md
+++ b/charts/zora/README.md
@@ -107,8 +107,11 @@ The following table lists the configurable parameters of the Zora chart and thei
 | scan.plugins.marvin.image.pullPolicy | string | `"Always"` | Image pull policy |
 | scan.plugins.marvin.env | list | `[]` | List of environment variables to set in marvin container. |
 | scan.plugins.marvin.envFrom | list | `[]` | List of sources to populate environment variables in marvin container. |
+| scan.plugins.trivy.args | string | `""` | Specifies custom arguments for the Trivy command-line. |
 | scan.plugins.trivy.ignoreUnfixed | bool | `false` | Specifies whether only fixed vulnerabilities should be reported |
 | scan.plugins.trivy.ignoreDescriptions | bool | `false` | Specifies whether vulnerability descriptions should be ignored |
+| scan.plugins.trivy.dbRepository | string | `""` | Specifies a custom OCI repository(ies) to retrieve vulnerability database. |
+| scan.plugins.trivy.javaDbRepository | string | `""` | Specifies a custom OCI repository(ies) to retrieve Java vulnerability database. |
 | scan.plugins.trivy.resources | object | `{"limits":{"cpu":"1500m","memory":"4096Mi"},"requests":{"cpu":"500m","memory":"2048Mi"}}` | [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) to add to `trivy` container |
 | scan.plugins.trivy.podAnnotations | object | `{}` | Annotations added to the trivy pods |
 | scan.plugins.trivy.image.repository | string | `"ghcr.io/undistro/trivy"` | trivy plugin image repository |

--- a/charts/zora/templates/plugins/trivy-job.yaml
+++ b/charts/zora/templates/plugins/trivy-job.yaml
@@ -57,6 +57,9 @@ spec:
                 {{- if .Values.scan.plugins.trivy.insecure }}
                 --insecure \
                 {{- end }}
+                {{- if .Values.scan.plugins.trivy.dbRepository }}
+                --db-repository={{ .Values.scan.plugins.trivy.dbRepository | quote }} \
+                {{- end }}
                 --download-db-only{{- if .Values.scan.plugins.trivy.persistence.downloadJavaDB }} && \
               time trivy image \
                 --debug \
@@ -64,6 +67,9 @@ spec:
                 --cache-dir=/tmp/trivy-cache \
                 {{- if .Values.scan.plugins.trivy.insecure }}
                 --insecure \
+                {{- end }}
+                {{- if .Values.scan.plugins.trivy.javaDbRepository }}
+                --java-db-repository={{ .Values.scan.plugins.trivy.javaDbRepository | quote }} \
                 {{- end }}
                 --download-java-db-only {{- end }}
                 exitcode=$(echo $?)

--- a/charts/zora/templates/plugins/trivy.yaml
+++ b/charts/zora/templates/plugins/trivy.yaml
@@ -72,7 +72,15 @@ spec:
         --ignore-unfixed \
         {{- end }}
         --timeout={{ .Values.scan.plugins.trivy.timeout | quote }} \
-        -o $(DONE_DIR)/results.json
+        {{- if .Values.scan.plugins.trivy.dbRepository }}
+        --db-repository={{ .Values.scan.plugins.trivy.dbRepository | quote }} \
+        {{- end }}
+        {{- if .Values.scan.plugins.trivy.javaDbRepository }}
+        --java-db-repository={{ .Values.scan.plugins.trivy.javaDbRepository | quote }} \
+        {{- end }}
+        -o $(DONE_DIR)/results.json {{- if .Values.scan.plugins.trivy.args }} \
+        {{ .Values.scan.plugins.trivy.args }}
+        {{- end }}
 
       exitcode=$(echo $?)
       if [ $exitcode -ne 0 ]; then

--- a/charts/zora/values.yaml
+++ b/charts/zora/values.yaml
@@ -178,10 +178,16 @@ scan:
       envFrom: []
 
     trivy:
+      # -- Specifies custom arguments for the Trivy command-line.
+      args: ""
       # -- Specifies whether only fixed vulnerabilities should be reported
       ignoreUnfixed: false
       # -- Specifies whether vulnerability descriptions should be ignored
       ignoreDescriptions: false
+      # -- Specifies a custom OCI repository(ies) to retrieve vulnerability database.
+      dbRepository: ""
+      # -- Specifies a custom OCI repository(ies) to retrieve Java vulnerability database.
+      javaDbRepository: ""
       # -- [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) to add to `trivy` container
       resources:
         requests:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -109,7 +109,7 @@ func main() {
 	flag.StringVar(&cronJobAnnotations, "cronjob-serviceaccount-annotations", "annotaion1=value1,annotation2=value2", "Annotations to be applied to the CronJob Service Account")
 	flag.StringVar(&saasWorkspaceID, "saas-workspace-id", "", "Your workspace ID in Zora SaaS")
 	flag.StringVar(&saasServer, "saas-server", "http://localhost:3003", "Address for Zora's saas server")
-	flag.StringVar(&version, "version", "0.10.4", "Zora version")
+	flag.StringVar(&version, "version", "0.10.5", "Zora version")
 	flag.StringVar(&checksConfigMapNamespace, "checks-configmap-namespace", "zora-system", "Namespace of custom checks ConfigMap")
 	flag.StringVar(&checksConfigMapName, "checks-configmap-name", "zora-custom-checks", "Name of custom checks ConfigMap")
 	flag.StringVar(&kubexnsImage, "kubexns-image", "ghcr.io/undistro/kubexns:latest", "kubexns image")

--- a/docs/configuration/https-proxy.md
+++ b/docs/configuration/https-proxy.md
@@ -24,3 +24,14 @@ While [Trivy](../plugins/trivy.md) downloads vulnerability databases during scan
 - `ghcr.io/aquasecurity/trivy-java-db`
 - `mirror.gcr.io/aquasec/trivy-db`
 - `mirror.gcr.io/aquasec/trivy-java-db`
+
+!!! note
+    A custom vulnerability database repository can be specified using the parameters `scan.plugins.trivy.dbRepository`
+    and `scan.plugins.trivy.javaDbRepository`.
+    You can use [skopeo](https://github.com/containers/skopeo/){:target="_blank"} to copy the official database to your 
+    own OCI-compliant registry with the command below.
+    Keep in mind that the original database is **continuously updated with new vulnerabilities**, 
+    so it's important to regularly synchronize your copy if you choose to host it yourself.
+    ```
+    skopeo copy docker://ghcr.io/aquasecurity/trivy-db:2 docker://registry.example.com/trivy-db:2
+    ```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -31,7 +31,7 @@ Then, run the following command to install or upgrade Zora [Helm chart](https://
     helm repo update undistro
     helm upgrade --install zora undistro/zora \
       -n zora-system \
-      --version 0.10.4 \
+      --version 0.10.5 \
       --create-namespace \
       --wait \
       --set clusterName="$(kubectl config current-context)"
@@ -42,7 +42,7 @@ Then, run the following command to install or upgrade Zora [Helm chart](https://
     ```shell
     helm upgrade --install zora oci://ghcr.io/undistro/helm-charts/zora \
       -n zora-system \
-      --version 0.10.4 \
+      --version 0.10.5 \
       --create-namespace \
       --wait \
       --set clusterName="$(kubectl config current-context)"


### PR DESCRIPTION
## Description
This PR adds support to customize Trivy vulnerability database repository and prepare the next release.

## Linked Issues

## How has this been tested?
Providing `--db-repository="docker.io/mfmoraes/trivy-db:2"` to Trivy command-line, which references a repository copied with Skopeo.

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [ ] My changes are covered by tests
