### PR TITLE
fix: support restricted PSS for plugin jobs

### DIFF
--- a/charts/zora/Chart.yaml
+++ b/charts/zora/Chart.yaml
@@ -17,7 +17,7 @@ name: zora
 description: A multi-plugin solution that reports misconfigurations and vulnerabilities by scanning your cluster at scheduled times.
 icon: https://zora-docs.undistro.io/v0.10/assets/logo.svg
 type: application
-version: 0.10.9
-appVersion: "v0.10.9"
+version: 0.11.0
+appVersion: "v0.11.0"
 sources:
   - https://github.com/undistro/zora

--- a/charts/zora/README.md
+++ b/charts/zora/README.md
@@ -1,6 +1,6 @@
 # Zora Helm Chart
 
-![Version: 0.10.9](https://img.shields.io/badge/Version-0.10.9-informational?style=flat-square&color=3CA9DD) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square&color=3CA9DD) ![AppVersion: v0.10.9](https://img.shields.io/badge/AppVersion-v0.10.9-informational?style=flat-square&color=3CA9DD)
+![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square&color=3CA9DD) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square&color=3CA9DD) ![AppVersion: v0.11.0](https://img.shields.io/badge/AppVersion-v0.11.0-informational?style=flat-square&color=3CA9DD)
 
 A multi-plugin solution that reports misconfigurations and vulnerabilities by scanning your cluster at scheduled times.
 
@@ -13,7 +13,7 @@ helm repo add undistro https://charts.undistro.io --force-update
 helm repo update undistro
 helm upgrade --install zora undistro/zora \
   -n zora-system \
-  --version 0.10.9 \
+  --version 0.11.0 \
   --create-namespace \
   --wait \
   --set clusterName="$(kubectl config current-context)"

--- a/charts/zora/README.md
+++ b/charts/zora/README.md
@@ -71,8 +71,8 @@ The following table lists the configurable parameters of the Zora chart and thei
 | operator.rbac.serviceAccount.annotations | object | `{}` | Annotations to be added to service account |
 | operator.rbac.serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | operator.podAnnotations | object | `{"kubectl.kubernetes.io/default-container":"manager"}` | Annotations to be added to pods |
-| operator.podSecurityContext | object | `{"runAsNonRoot":true}` | [Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context) to add to the pod |
-| operator.securityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true}` | [Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context) to add to `manager` container |
+| operator.podSecurityContext | object | `{"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | [Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context) to add to the pod |
+| operator.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | [Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context) to add to `manager` container |
 | operator.metricsService.type | string | `"ClusterIP"` | Type of metrics service |
 | operator.metricsService.port | int | `8443` | Port of metrics service |
 | operator.serviceMonitor.enabled | bool | `false` | Specifies whether a Prometheus `ServiceMonitor` should be enabled |
@@ -101,6 +101,7 @@ The following table lists the configurable parameters of the Zora chart and thei
 | scan.plugins.marvin.affinity | object | `{}` | Map of node/pod [affinities](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration) |
 | scan.plugins.marvin.resources | object | `{"limits":{"cpu":"500m","memory":"500Mi"},"requests":{"cpu":"250m","memory":"256Mi"}}` | [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) to add to `marvin` container |
 | scan.plugins.marvin.workerResources | object | `{"limits":{"cpu":"500m","memory":"256Mi"},"requests":{"cpu":"10m","memory":"64Mi"}}` | [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) to add to `worker` container |
+| scan.plugins.marvin.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context applied to the marvin, worker and checks containers |
 | scan.plugins.marvin.podAnnotations | object | `{}` | Annotations added to the marvin pods |
 | scan.plugins.marvin.image.repository | string | `"ghcr.io/undistro/marvin"` | marvin plugin image repository |
 | scan.plugins.marvin.image.tag | string | `"v0.2"` | marvin plugin image tag |
@@ -117,6 +118,7 @@ The following table lists the configurable parameters of the Zora chart and thei
 | scan.plugins.trivy.affinity | object | `{}` | Map of node/pod [affinities](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration) |
 | scan.plugins.trivy.resources | object | `{"limits":{"cpu":"1500m","memory":"4096Mi"},"requests":{"cpu":"500m","memory":"2048Mi"}}` | [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) to add to `trivy` container |
 | scan.plugins.trivy.workerResources | object | `{"limits":{"cpu":"500m","memory":"256Mi"},"requests":{"cpu":"10m","memory":"64Mi"}}` | [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) to add to `worker` container |
+| scan.plugins.trivy.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context applied to the trivy, worker and checks containers |
 | scan.plugins.trivy.podAnnotations | object | `{}` | Annotations added to the trivy pods |
 | scan.plugins.trivy.image.repository | string | `"ghcr.io/undistro/trivy"` | trivy plugin image repository |
 | scan.plugins.trivy.image.tag | float | `0.74` | trivy plugin image tag |
@@ -137,6 +139,7 @@ The following table lists the configurable parameters of the Zora chart and thei
 | scan.plugins.popeye.affinity | object | `{}` | Map of node/pod [affinities](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration) |
 | scan.plugins.popeye.resources | object | `{"limits":{"cpu":"500m","memory":"500Mi"},"requests":{"cpu":"250m","memory":"256Mi"}}` | [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) to add to `popeye` container |
 | scan.plugins.popeye.workerResources | object | `{"limits":{"cpu":"500m","memory":"256Mi"},"requests":{"cpu":"10m","memory":"64Mi"}}` | [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) to add to `worker` container |
+| scan.plugins.popeye.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context applied to the popeye, worker and checks containers |
 | scan.plugins.popeye.podAnnotations | object | `{}` | Annotations added to the popeye pods |
 | scan.plugins.popeye.image.repository | string | `"ghcr.io/undistro/popeye"` | popeye plugin image repository |
 | scan.plugins.popeye.image.tag | float | `0.21` | popeye plugin image tag |

--- a/charts/zora/templates/operator/deployment.yaml
+++ b/charts/zora/templates/operator/deployment.yaml
@@ -37,7 +37,7 @@ data:
   ca.crt: {{ b64enc $ca.Cert }}
 {{- end }}
 ---
-{{- end -}}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/zora/templates/plugins/marvin.yaml
+++ b/charts/zora/templates/plugins/marvin.yaml
@@ -55,9 +55,7 @@ spec:
   {{- end }}
   mountCustomChecksVolume: true
   securityContext:
-    runAsNonRoot: true
-    readOnlyRootFilesystem: true
-    allowPrivilegeEscalation: false
+    {{- toYaml .Values.scan.plugins.marvin.securityContext | nindent 4 }}
   {{- with .Values.scan.plugins.marvin.envFrom }}
   envFrom:
     {{- toYaml . | nindent 4}}

--- a/charts/zora/templates/plugins/popeye.yaml
+++ b/charts/zora/templates/plugins/popeye.yaml
@@ -69,8 +69,7 @@ spec:
     {{- toYaml . | nindent 4}}
   {{- end }}
   securityContext:
-    runAsNonRoot: true
-    allowPrivilegeEscalation: false
+    {{- toYaml .Values.scan.plugins.popeye.securityContext | nindent 4 }}
   {{- if .Values.scan.plugins.popeye.podAnnotations }}
   annotations:
     {{- toYaml .Values.scan.plugins.popeye.podAnnotations | nindent 4 }}

--- a/charts/zora/templates/plugins/trivy.yaml
+++ b/charts/zora/templates/plugins/trivy.yaml
@@ -55,9 +55,7 @@ spec:
   {{- end }}
   mountCustomChecksVolume: false
   securityContext:
-    runAsNonRoot: true
-    allowPrivilegeEscalation: false
-    privileged: false
+    {{- toYaml .Values.scan.plugins.trivy.securityContext | nindent 4 }}
   {{- with .Values.scan.plugins.trivy.envFrom }}
   envFrom:
     {{- toYaml . | nindent 4}}

--- a/charts/zora/values.yaml
+++ b/charts/zora/values.yaml
@@ -72,10 +72,15 @@ operator:
   # -- [Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context) to add to the pod
   podSecurityContext:
     runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   # -- [Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context) to add to `manager` container
   securityContext:
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
   metricsService:
     # -- Type of metrics service
     type: ClusterIP
@@ -167,6 +172,16 @@ scan:
         requests:
           cpu: 10m
           memory: 64Mi
+      # -- Security context applied to the marvin, worker and checks containers
+      securityContext:
+        runAsNonRoot: true
+        readOnlyRootFilesystem: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
       # -- Annotations added to the marvin pods
       podAnnotations: {}
       image:
@@ -214,6 +229,16 @@ scan:
         requests:
           cpu: 10m
           memory: 64Mi
+      # -- Security context applied to the trivy, worker and checks containers
+      securityContext:
+        runAsNonRoot: true
+        allowPrivilegeEscalation: false
+        privileged: false
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
       # -- Annotations added to the trivy pods
       podAnnotations: {}
       image:
@@ -290,6 +315,15 @@ scan:
         requests:
           cpu: 10m
           memory: 64Mi
+      # -- Security context applied to the popeye, worker and checks containers
+      securityContext:
+        runAsNonRoot: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
       # -- Annotations added to the popeye pods
       podAnnotations: {}
       image:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -109,7 +109,7 @@ func main() {
 	flag.StringVar(&cronJobAnnotations, "cronjob-serviceaccount-annotations", "annotaion1=value1,annotation2=value2", "Annotations to be applied to the CronJob Service Account")
 	flag.StringVar(&saasWorkspaceID, "saas-workspace-id", "", "Your workspace ID in Zora SaaS")
 	flag.StringVar(&saasServer, "saas-server", "http://localhost:3003", "Address for Zora's saas server")
-	flag.StringVar(&version, "version", "0.10.9", "Zora version")
+	flag.StringVar(&version, "version", "0.11.0", "Zora version")
 	flag.StringVar(&checksConfigMapNamespace, "checks-configmap-namespace", "zora-system", "Namespace of custom checks ConfigMap")
 	flag.StringVar(&checksConfigMapName, "checks-configmap-name", "zora-custom-checks", "Name of custom checks ConfigMap")
 	flag.StringVar(&kubexnsImage, "kubexns-image", "ghcr.io/undistro/kubexns:latest", "kubexns image")

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -31,7 +31,7 @@ Then, run the following command to install or upgrade Zora [Helm chart](https://
     helm repo update undistro
     helm upgrade --install zora undistro/zora \
       -n zora-system \
-      --version 0.10.9 \
+      --version 0.11.0 \
       --create-namespace \
       --wait \
       --set clusterName="$(kubectl config current-context)"
@@ -42,7 +42,7 @@ Then, run the following command to install or upgrade Zora [Helm chart](https://
     ```shell
     helm upgrade --install zora oci://ghcr.io/undistro/helm-charts/zora \
       -n zora-system \
-      --version 0.10.9 \
+      --version 0.11.0 \
       --create-namespace \
       --wait \
       --set clusterName="$(kubectl config current-context)"

--- a/pkg/plugins/cronjob.go
+++ b/pkg/plugins/cronjob.go
@@ -230,10 +230,7 @@ func (r *CronJobMutator) workerContainer() corev1.Container {
 		Resources:       r.Plugin.Spec.WorkerResourcesOrDefault(),
 		VolumeMounts:    commonVolumeMounts,
 		ImagePullPolicy: corev1.PullIfNotPresent,
-		SecurityContext: &corev1.SecurityContext{
-			RunAsNonRoot:             pointer.Bool(true),
-			AllowPrivilegeEscalation: pointer.Bool(false),
-		},
+		SecurityContext: r.pluginSecurityContext(),
 	}
 }
 
@@ -276,11 +273,28 @@ func (r *CronJobMutator) initContainer() corev1.Container {
 		VolumeMounts:    []corev1.VolumeMount{customChecksVolume},
 		ImagePullPolicy: corev1.PullPolicy(r.KubexnsPullPolicy),
 		Resources:       r.Plugin.Spec.WorkerResourcesOrDefault(),
-		SecurityContext: &corev1.SecurityContext{
+		SecurityContext: r.pluginSecurityContext(),
+	}
+}
+
+// pluginSecurityContext returns a copy of the Plugin security context for
+// containers created by the operator. Keep a safe default for Plugin objects
+// created outside the Helm chart, which may not set securityContext.
+func (r *CronJobMutator) pluginSecurityContext() *corev1.SecurityContext {
+	if r.Plugin.Spec.SecurityContext == nil {
+		return &corev1.SecurityContext{
 			RunAsNonRoot:             pointer.Bool(true),
 			AllowPrivilegeEscalation: pointer.Bool(false),
-		},
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+			},
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeRuntimeDefault,
+			},
+		}
 	}
+
+	return r.Plugin.Spec.SecurityContext.DeepCopy()
 }
 
 // pluginEnv returns a list of environment variables to set in the Plugin container

--- a/pkg/plugins/cronjob_test.go
+++ b/pkg/plugins/cronjob_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 Undistro Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugins
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
+
+	"github.com/undistro/zora/api/zora/v1alpha1"
+)
+
+func TestCronJobMutatorAppliesPluginSecurityContextToSupportContainers(t *testing.T) {
+	securityContext := &corev1.SecurityContext{
+		RunAsNonRoot:             pointer.Bool(true),
+		AllowPrivilegeEscalation: pointer.Bool(false),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+
+	mutator := &CronJobMutator{
+		Plugin: &v1alpha1.Plugin{Spec: v1alpha1.PluginSpec{SecurityContext: securityContext}},
+		ClusterScan: &v1alpha1.ClusterScan{Spec: v1alpha1.ClusterScanSpec{
+			ClusterRef: corev1.LocalObjectReference{Name: "test-cluster"},
+		}},
+	}
+
+	worker := mutator.workerContainer()
+	checks := mutator.initContainer()
+
+	if !reflect.DeepEqual(worker.SecurityContext, securityContext) {
+		t.Fatalf("worker security context = %#v, want %#v", worker.SecurityContext, securityContext)
+	}
+	if !reflect.DeepEqual(checks.SecurityContext, securityContext) {
+		t.Fatalf("checks security context = %#v, want %#v", checks.SecurityContext, securityContext)
+	}
+
+	worker.SecurityContext.Capabilities.Drop[0] = "CHOWN"
+	if checks.SecurityContext.Capabilities.Drop[0] != "ALL" {
+		t.Fatal("worker and checks security contexts share mutable state")
+	}
+}
+
+func TestCronJobMutatorUsesSafeDefaultSecurityContext(t *testing.T) {
+	mutator := &CronJobMutator{
+		Plugin:      &v1alpha1.Plugin{},
+		ClusterScan: &v1alpha1.ClusterScan{},
+	}
+
+	want := &corev1.SecurityContext{
+		RunAsNonRoot:             pointer.Bool(true),
+		AllowPrivilegeEscalation: pointer.Bool(false),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+
+	if got := mutator.workerContainer().SecurityContext; !reflect.DeepEqual(got, want) {
+		t.Fatalf("worker security context = %#v, want %#v", got, want)
+	}
+	if got := mutator.initContainer().SecurityContext; !reflect.DeepEqual(got, want) {
+		t.Fatalf("checks security context = %#v, want %#v", got, want)
+	}
+}


### PR DESCRIPTION
## Description
- Expose `securityContext` values for Marvin, Popeye and Trivy in the Helm Chart.
- Apply the Plugin security context to the generated `worker` and `checks` containers.
- Update the operator fallback with `runAsNonRoot`, `allowPrivilegeEscalation: false`, dropping all capabilities and `RuntimeDefault` seccomp.
- Harden the operator default security context.
- Update the Helm Chart documentation.

## Linked Issues
Fixes https://github.com/undistro/zora/issues/337

## How has this been tested?
- `go test ./...`
- `helm lint charts/zora --set clusterName=test`
- `helm template zora charts/zora --set clusterName=test`
- Installed on a Kind cluster and waited for scans to complete successfully

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [x] My changes are covered by tests
